### PR TITLE
[WIP] Openapi spec

### DIFF
--- a/galaxy_api/fields.py
+++ b/galaxy_api/fields.py
@@ -1,0 +1,84 @@
+# (c) 2012-2018, Ansible by Red Hat
+#
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+
+import distutils.version
+
+import semantic_version
+
+from django.db import models
+
+
+__all__ = [
+    'TruncatingCharField',
+    'VersionField',
+]
+
+
+class VersionField(models.CharField):
+    """Semantic version field"""
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('max_length', 64)
+        super().__init__(*args, **kwargs)
+
+    def from_db_value(self, value, expression, connection):
+        if value is None:
+            return value
+        return semantic_version.Version(value)
+
+    def to_python(self, value):
+        if isinstance(value, semantic_version.Version):
+            return value
+        if value is None:
+            return value
+        return semantic_version.Version(value)
+
+    def get_prep_value(self, value):
+        if value is None:
+            return value
+        return str(value)
+
+
+# TODO(cutwater): LooseVersionField is not used in actual models and is kept
+# only because it's referenced by migration 0001_initial.py
+class LooseVersionField(models.Field):
+    """ store and return values as a LooseVersion """
+
+    def db_type(self, connection):
+        return 'varchar(64)'
+
+    def get_internal_type(self):
+        return 'CharField'
+
+    def value_to_string(self, obj):
+        value = self._get_val_from_obj(obj)
+        return self.get_prep_value(value)
+
+    def to_python(self, value):
+        return distutils.version.LooseVersion(value)
+
+    def get_prep_value(self, value):
+        return str(value)
+
+
+# From: http://stackoverflow.com/questions/3459843/auto-truncating-fields-at-max-length-in-django-charfields # noqa: E501
+class TruncatingCharField(models.CharField):
+    def get_prep_value(self, value):
+        value = super().get_prep_value(value)
+        if value and len(value) > self.max_length:
+            return value[:self.max_length - 3] + '...'
+        return value

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -695,6 +695,220 @@ paths:
               schema:
                 $ref: '#/components/schemas/Tag'
 
+  /pulp/api/v3/tasks/:
+    get:
+      tags:
+        - tasks
+        - pulp
+        - v3
+      summary: List tasks
+      operationId: GetPulpTasks
+      parameters:
+        - name: ordering
+          in: query
+          description: Which field to use when ordering the results.
+          schema:
+            type: string
+        - name: state
+          in: query
+          schema:
+            type: string
+        - name: state__in
+          in: query
+          description: Filter results where state is in a comma-separated list of values
+          schema:
+            type: string
+        - name: worker
+          in: query
+          description: Foreign Key referenced by HREF
+          schema:
+            type: string
+        - name: worker__in
+          in: query
+          description: Filter results where worker is in a comma-separated list of values
+          schema:
+            type: string
+        - name: name__contains
+          in: query
+          description: Filter results where name contains value
+          schema:
+            type: string
+        - name: started_at__lt
+          in: query
+          description: Filter results where started_at is less than value
+          schema:
+            type: string
+        - name: started_at__lte
+          in: query
+          description: Filter results where started_at is less than or equal to value
+          schema:
+            type: string
+        - name: started_at__gt
+          in: query
+          description: Filter results where started_at is greater than value
+          schema:
+            type: string
+        - name: started_at__gte
+          in: query
+          description: Filter results where started_at is greater than or equal to value
+          schema:
+            type: string
+        - name: started_at__range
+          in: query
+          description: >-
+            Filter results where started_at is between two comma separated
+            values
+          schema:
+            type: string
+        - name: finished_at__lt
+          in: query
+          description: Filter results where finished_at is less than value
+          schema:
+            type: string
+        - name: finished_at__lte
+          in: query
+          description: Filter results where finished_at is less than or equal to value
+          schema:
+            type: string
+        - name: finished_at__gt
+          in: query
+          description: Filter results where finished_at is greater than value
+          schema:
+            type: string
+        - name: finished_at__gte
+          in: query
+          description: Filter results where finished_at is greater than or equal to value
+          schema:
+            type: string
+        - name: finished_at__range
+          in: query
+          description: >-
+            Filter results where finished_at is between two comma separated
+            values
+          schema:
+            type: string
+        - name: parent
+          in: query
+          description: Foreign Key referenced by HREF
+          schema:
+            type: string
+        - name: name
+          in: query
+          schema:
+            type: string
+        - name: started_at
+          in: query
+          description: ISO 8601 formatted dates are supported
+          schema:
+            type: string
+        - name: finished_at
+          in: query
+          description: ISO 8601 formatted dates are supported
+          schema:
+            type: string
+        - name: page
+          in: query
+          description: A page number within the paginated result set.
+          schema:
+            type: integer
+        - name: page_size
+          in: query
+          description: Number of results to return per page.
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                required:
+                  - count
+                  - results
+                type: object
+                properties:
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  count:
+                    type: integer
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PulpTask'
+  '/{task_href}':
+    get:
+      tags:
+        - tasks
+        - pulp
+        - v3
+      summary: Inspect a task
+      operationId: GetPulpTask
+      parameters:
+        - name: task_href
+          in: path
+          description: 'URI of Task. e.g.: /pulp/api/v3/tasks/1/'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PulpTask'
+    delete:
+      tags:
+        - tasks
+        - pulp
+        - v3
+      summary: Delete a task
+      operationId: DeletePulpTask
+      parameters:
+        - name: task_href
+          in: path
+          description: 'URI of Task. e.g.: /pulp/api/v3/tasks/1/'
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: ''
+          content: {}
+    patch:
+      tags:
+        - tasks
+        - pulp
+        - v3
+      summary: Cancel a task
+      description: This operation cancels a task.
+      operationId: PatchPulpTask
+      parameters:
+        - name: task_href
+          in: path
+          description: 'URI of Task. e.g.: /pulp/api/v3/tasks/1/'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PulpTaskCancel'
+        required: true
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PulpTask'
   '/users/':
     get:
       summary: 'Get a list of Users'
@@ -1317,10 +1531,12 @@ components:
 
     PageNext:
       type: string
+      format: uri
 
     PagePrevious:
       description: 'The previous page'
       type: string
+      format: uri
 
     ProviderNamespace:
       description: 'A Provider Namespace'
@@ -1523,7 +1739,144 @@ components:
                 $ref: '#/components/schemas/Tag'
           required:
             - results
-
+    PulpProgressReport:
+      type: object
+      properties:
+        message:
+          title: Message
+          minLength: 1
+          type: string
+          description: The message shown to the user for the progress report.
+          readOnly: true
+        state:
+          title: State
+          minLength: 1
+          type: string
+          description: >-
+            The current state of the progress report. The possible values are:
+            'waiting', 'skipped', 'running', 'completed', 'failed' and
+            'canceled'. The default is 'waiting'.
+          readOnly: true
+        total:
+          title: Total
+          type: integer
+          description: The total count of items to be handled by the ProgressBar.
+          readOnly: true
+        done:
+          title: Done
+          type: integer
+          description: The count of items already processed. Defaults to 0.
+          readOnly: true
+        suffix:
+          title: Suffix
+          minLength: 1
+          type: string
+          description: The suffix to be shown with the progress report.
+          nullable: true
+          readOnly: true
+    PulpTask:
+      required:
+        - name
+      type: object
+      properties:
+        _href:
+          title: ' href'
+          type: string
+          format: uri
+          readOnly: true
+        _created:
+          title: ' created'
+          type: string
+          description: Timestamp of creation.
+          format: date-time
+          readOnly: true
+        state:
+          title: State
+          minLength: 1
+          type: string
+          description: >-
+            The current state of the task. The possible values include:
+            'waiting', 'skipped', 'running', 'completed', 'failed' and
+            'canceled'.
+          readOnly: true
+        name:
+          title: Name
+          minLength: 1
+          type: string
+          description: The name of task.
+        started_at:
+          title: Started at
+          type: string
+          description: Timestamp of the when this task started execution.
+          format: date-time
+          readOnly: true
+        finished_at:
+          title: Finished at
+          type: string
+          description: Timestamp of the when this task stopped execution.
+          format: date-time
+          readOnly: true
+        non_fatal_errors:
+          title: Non fatal errors
+          type: string
+          description: >-
+            A JSON Object of non-fatal errors encountered during the execution
+            of this task.
+          readOnly: true
+        error:
+          title: Error
+          type: string
+          description: >-
+            A JSON Object of a fatal error encountered during the execution of
+            this task.
+          readOnly: true
+        worker:
+          title: Worker
+          type: string
+          description: >-
+            The worker associated with this task. This field is empty if a
+            worker is not yet assigned.
+          format: uri
+          readOnly: true
+        parent:
+          title: Parent
+          type: string
+          description: The parent task that spawned this task.
+          format: uri
+          readOnly: true
+        spawned_tasks:
+          uniqueItems: true
+          type: array
+          description: Any tasks spawned by this task.
+          readOnly: true
+          items:
+            type: string
+            description: Any tasks spawned by this task.
+            format: uri
+        progress_reports:
+          type: array
+          readOnly: true
+          items:
+            $ref: '#/components/schemas/PulpProgressReport'
+        created_resources:
+          uniqueItems: true
+          type: array
+          description: Resources created by this task.
+          readOnly: true
+          items:
+            type: string
+            description: Resources created by this task.
+            format: uri
+    PulpTaskCancel:
+      required:
+        - state
+      type: object
+      properties:
+        state:
+          title: State
+          minLength: 1
+          type: string
+          description: The desired state of the task. Only 'canceled' is accepted.
     User:
       description: 'A User'
       title: 'User'

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -13,8 +13,8 @@ servers:
     description: 'Production server (uses live data)'
   - url: https://galaxy-dev.ansible.com/
     description: 'shared public dev server'
-  - url: http://localhost:8000
-    description: 'local sandbox'
+  - url: http://localhost:5001
+    description: 'local dev server'
     
 externalDocs:
   url: https://galaxy.ansible.com/docs/
@@ -100,6 +100,10 @@ paths:
       tags:
         - me
         - v1
+      security:
+        - TokenAuth: []
+        - TokenApiKey: []
+        - BasicAuth: []
       parameters:
         - $ref: '#/components/parameters/Search'
       responses:
@@ -329,6 +333,10 @@ paths:
         - collections
         - v2
         - client_mazer
+      security:
+        - TokenAuth: []
+        - TokenApiKey: []
+        - BasicAuth: []
       parameters: []
       requestBody:
         $ref: '#/components/requestBodies/CollectionVersionArtifactBody'
@@ -339,6 +347,12 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '409':
           $ref: '#/components/responses/Conflict'
+        default:
+          description: 'Unexpected Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
           
   '/api/v2/collections/{id}/':
     get:
@@ -1242,6 +1256,17 @@ components:
                 
     Unauthorized:
       description: 'Authorization error'
+      headers:
+        WWW-Authenticate:
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/APIException'
+
+    NotFound:
+      description: 'Not Found (404)'
       content:
         application/json:
           schema:
@@ -1407,3 +1432,13 @@ components:
         multipart/form-data:
           schema:
             $ref: '#/components/schemas/CollectionVersionArtifactData'
+
+  securitySchemes:
+    BasicAuth:
+      type: http
+      scheme: basic
+    TokenApiKey:
+      description: Provide a Galaxy API token in "Authorization" header with value in form "Token {api_key}"
+      type: apiKey
+      in: header
+      name: Authorization

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -78,8 +78,10 @@ paths:
         - v2
         - client_mazer
       security:
-        - TokenApiKey: []
-        - BasicAuth: []
+        - UserTokenApiKey: []
+        - UserBasicAuth: []
+        - AdminTokenApiKey: []
+        - AdminBasicAuth: []
       parameters: []
       requestBody:
         $ref: '#/components/requestBodies/CollectionVersionArtifactBody'
@@ -285,8 +287,10 @@ paths:
         - v3
         - collection-version-artifacts
       security:
-        - TokenApiKey: []
-        - BasicAuth: []
+        - UserTokenApiKey: []
+        - UserBasicAuth: []
+        - AdminTokenApiKey: []
+        - AdminBasicAuth: []
       parameters: []
       requestBody:
         $ref: '#/components/requestBodies/CollectionVersionArtifactBody'
@@ -364,8 +368,8 @@ paths:
         - me
         - v1
       security:
-        - TokenApiKey: []
-        - BasicAuth: []
+        - UserTokenApiKey: []
+        - UserBasicAuth: []
       parameters:
         - $ref: '#/components/parameters/Search'
       responses:
@@ -390,10 +394,14 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Namespaces'
+
     post:
       operationId: 'CreateNamespace'
       summary: 'Create a Namespace'
       parameters: []
+      security:
+        - AdminTokenApiKey: []
+        - AdminBasicAuth: []
       requestBody:
         $ref: '#/components/requestBodies/Namespace'
       responses:
@@ -420,6 +428,9 @@ paths:
       operationId: 'UpdateNamespace'
       parameters:
         - $ref: '#/components/parameters/NamespaceId'
+      security:
+        - AdminTokenApiKey: []
+        - AdminBasicAuth: []
       requestBody:
         $ref: '#/components/requestBodies/Namespace'
       responses:
@@ -433,6 +444,9 @@ paths:
       operationId: DeleteNamespace
       parameters:
         - $ref: '#/components/parameters/NamespaceId'
+      security:
+        - AdminTokenApiKey: []
+        - AdminBasicAuth: []
       responses:
         '204':
           $ref: '#/components/responses/DeleteSuccessful'
@@ -458,6 +472,9 @@ paths:
       operationId: CreateProviderNamespace
       summary: 'Create a Provider Namespace'
       parameters: []
+      security:
+        - AdminTokenApiKey: []
+        - AdminBasicAuth: []
       requestBody:
         $ref: '#/components/requestBodies/ProviderNamespace'
       responses:
@@ -485,6 +502,9 @@ paths:
       description: 'Update a Provider Namespace'
       parameters:
         - $ref: '#/components/parameters/ProviderNamespaceId'
+      security:
+        - AdminTokenApiKey: []
+        - AdminBasicAuth: []
       requestBody:
         $ref: '#/components/requestBodies/ProviderNamespace'
       responses:
@@ -499,6 +519,9 @@ paths:
       description: 'Delete a Provider Namespace'
       parameters:
         - $ref: '#/components/parameters/ProviderNamespaceId'
+      security:
+        - AdminTokenApiKey: []
+        - AdminBasicAuth: []
       responses:
         '204':
           $ref: '#/components/responses/DeleteSuccessful'
@@ -518,71 +541,43 @@ paths:
         Wrapper for https://pulp-ansible.readthedocs.io/en/latest/restapi.html#operation/content_ansible_collections_list
       operationId: GetPulpContentAnsibleCollections
       parameters:
-      - name: name
-        in: query
-        description: Filter results where name matches value
-        schema:
-          type: string
-      - name: namespace
-        in: query
-        description: Filter results where namespace matches value
-        schema:
-          type: string
-      - name: version
-        in: query
-        description: Filter results where version matches value
-        schema:
-          type: string
-      - name: repository_version
-        in: query
-        description: Repository Version referenced by HREF
-        schema:
-          type: string
-      - name: repository_version_added
-        in: query
-        description: Repository Version referenced by HREF
-        schema:
-          type: string
-      - name: repository_version_removed
-        in: query
-        description: Repository Version referenced by HREF
-        schema:
-          type: string
-      - name: page
-        in: query
-        description: A page number within the paginated result set.
-        schema:
-          type: integer
-      - name: page_size
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Search'
+        - name: name
+          in: query
+          description: Filter results where name matches value
+          schema:
+            type: string
+        - name: namespace
+          in: query
+          description: Filter results where namespace matches value
+          schema:
+            type: string
+        - name: version
+          in: query
+          description: Filter results where version matches value
+          schema:
+            type: string
+        - name: repository_version
+          in: query
+          description: Repository Version referenced by HREF
+          schema:
+            type: string
+        - name: repository_version_added
+          in: query
+          description: Repository Version referenced by HREF
+          schema:
+            type: string
+        - name: repository_version_removed
+          in: query
+          description: Repository Version referenced by HREF
+          schema:
+            type: string
       responses:
         200:
-          description: "response from getting pulp collection content"
-          content:
-            application/json:
-              schema:
-                required:
-                - count
-                - results
-                type: object
-                properties:
-                  next:
-                    type: string
-                    format: uri
-                    nullable: true
-                  previous:
-                    type: string
-                    format: uri
-                    nullable: true
-                  count:
-                    type: integer
-                  results:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/PulpCollection'
+          $ref: '#/components/responses/PulpContentAnsibleCollections'
+
     post:
       summary: Create a collection
       description: |
@@ -593,6 +588,11 @@ paths:
         - pulp
         - collections
         - v3
+      security:
+        - UserTokenApiKey: []
+        - UserBasicAuth: []
+        - AdminTokenApiKey: []
+        - AdminBasicAuth: []
       requestBody:
         content:
           application/json:
@@ -619,6 +619,9 @@ paths:
       description: 'Wrapper for Pulp API GET /pulp/api/v3/tasks/'
       operationId: GetPulpTasks
       parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Search'
         - name: ordering
           in: query
           description: Which field to use when ordering the results.
@@ -721,41 +724,9 @@ paths:
           description: ISO 8601 formatted dates are supported
           schema:
             type: string
-        - name: page
-          in: query
-          description: A page number within the paginated result set.
-          schema:
-            type: integer
-        - name: page_size
-          in: query
-          description: Number of results to return per page.
-          schema:
-            type: integer
       responses:
         '200':
-          description: ''
-          content:
-            application/json:
-              schema:
-                required:
-                  - count
-                  - results
-                type: object
-                properties:
-                  next:
-                    type: string
-                    format: uri
-                    nullable: true
-                  previous:
-                    type: string
-                    format: uri
-                    nullable: true
-                  count:
-                    type: integer
-                  results:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/PulpTask'
+          $ref: '#/components/responses/PulpTasks'
 
   '/pulp/tasks/{pulp_task_id}':
     description: 'Wrapper API for Pulp {task_href}'
@@ -795,10 +766,14 @@ paths:
           required: true
           schema:
             type: string
+      security:
+        - UserTokenApiKey: []
+        - UserBasicAuth: []
+        - AdminTokenApiKey: []
+        - AdminBasicAuth: []
       responses:
-        '204':
-          description: ''
-          content: {}
+        204:
+          description: A DELETE operation was successful
     patch:
       tags:
         - tasks
@@ -814,6 +789,11 @@ paths:
           required: true
           schema:
             type: string
+      security:
+        - UserTokenApiKey: []
+        - UserBasicAuth: []
+        - AdminTokenApiKey: []
+        - AdminBasicAuth: []
       requestBody:
         content:
           application/json:
@@ -903,6 +883,31 @@ paths:
         '200':
           $ref: '#/components/responses/Tags'
 
+    post:
+      summary: 'Create a Galaxy Tag'
+      operationId: CreateTag
+      tags:
+        - tags
+        - v1
+      security:
+        - UserTokenApiKey: []
+        - UserBasicAuth: []
+        - AdminTokenApiKey: []
+        - AdminBasicAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Tag'
+        required: true
+      responses:
+        201:
+          description: "Tag creation was succesful"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tag'
+
   '/tags/{id}/':
     get:
       summary: 'Get a Galaxy Tag'
@@ -911,16 +916,39 @@ paths:
         - tags
         - v1
       parameters:
-        - description: 'Tag id'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/TagId'
         - $ref: '#/components/parameters/Search'
       responses:
         '200':
           description: 'A Galaxy Tag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tag'
+
+    patch:
+      summary: 'Patch/update a Tag by id'
+      operationId: PatchTagById
+      tags:
+        - tags
+        - v1
+      parameters:
+        - $ref: '#/components/parameters/TagId'
+        - $ref: '#/components/parameters/Search'
+      security:
+        - UserTokenApiKey: []
+        - UserBasicAuth: []
+        - AdminTokenApiKey: []
+        - AdminBasicAuth: []
+      requestBody:
+        description: 'An Tag to update to'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Tag'
+      responses:
+        '200':
+          description: 'The Tag updated by the PATCH'
           content:
             application/json:
               schema:
@@ -968,13 +996,17 @@ paths:
       parameters:
         - $ref: '#/components/parameters/UserId'
         - $ref: '#/components/parameters/Search'
+      security:
+        - UserTokenApiKey: []
+        - UserBasicAuth: []
+        - AdminTokenApiKey: []
+        - AdminBasicAuth: []
       requestBody:
         description: 'An User to update to'
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UserUpdate'
-
       responses:
         '200':
           description: 'The User updated by the PATCH'
@@ -1608,14 +1640,8 @@ components:
           required:
             - results
 
-    PulpCollection:
-      title: 'PulpCollection'
-      description: 'A Collection as stored in Pulp'
-      required:
-        - _artifact
-        - name
-        - namespace
-        - version
+    PulpBase:
+      description: 'A base class for Pulp objects'
       type: object
       properties:
         _href:
@@ -1623,34 +1649,62 @@ components:
           type: string
           format: uri
           readOnly: true
-        _type:
-          title: ' type'
-          minLength: 1
-          type: string
-          readOnly: true
-        _artifact:
-          title: ' artifact'
-          type: string
-          description: Artifact file representing the physical content
-          format: uri
         _created:
           title: ' created'
           type: string
           description: Timestamp of creation.
           format: date-time
           readOnly: true
-        version:
-          title: Version
-          minLength: 1
-          type: string
-        name:
-          title: Name
-          minLength: 1
-          type: string
-        namespace:
-          title: Namespace
-          minLength: 1
-          type: string
+
+    PulpCollection:
+      title: 'PulpCollection'
+      description: 'A Collection as stored in Pulp'
+      allOf:
+        - $ref: '#/components/schemas/PulpBase'
+        - type: object
+          properties:
+            _type:
+              title: ' type'
+              minLength: 1
+              type: string
+              readOnly: true
+            _artifact:
+              title: ' artifact'
+              type: string
+              description: Artifact file representing the physical content
+              format: uri
+            version:
+              title: Version
+              minLength: 1
+              type: string
+            name:
+              title: Name
+              minLength: 1
+              type: string
+            namespace:
+              title: Namespace
+              minLength: 1
+              type: string
+          required:
+            - _artifact
+            - name
+            - namespace
+            - version
+
+    PulpContentAnsibleCollectionsPage:
+      description: 'A page of a list of PulpContentAnsibleCollections'
+      title: 'Pulp ContentAnsibleCollections Page'
+      allOf:
+        - $ref: '#/components/schemas/PageInfo'
+        - type: object
+          properties:
+            results:
+              title: 'PulpCollections'
+              type: array
+              items:
+                $ref: '#/components/schemas/PulpCollection'
+          required:
+            - results
 
     PulpProgressReport:
       type: object
@@ -1689,98 +1743,92 @@ components:
           readOnly: true
 
     PulpTask:
-      required:
-        - name
-      type: object
-      properties:
-        _href:
-          title: ' href'
-          type: string
-          format: uri
-          readOnly: true
-        _created:
-          title: ' created'
-          type: string
-          description: Timestamp of creation.
-          format: date-time
-          readOnly: true
-        state:
-          title: State
-          minLength: 1
-          type: string
-          description: >-
-            The current state of the task. The possible values include:
-            'waiting', 'skipped', 'running', 'completed', 'failed' and
-            'canceled'.
-          readOnly: true
-        name:
-          title: Name
-          minLength: 1
-          type: string
-          description: The name of task.
-        started_at:
-          title: Started at
-          type: string
-          description: Timestamp of the when this task started execution.
-          format: date-time
-          readOnly: true
-        finished_at:
-          title: Finished at
-          type: string
-          description: Timestamp of the when this task stopped execution.
-          format: date-time
-          readOnly: true
-        non_fatal_errors:
-          title: Non fatal errors
-          type: string
-          description: >-
-            A JSON Object of non-fatal errors encountered during the execution
-            of this task.
-          readOnly: true
-        error:
-          title: Error
-          type: string
-          description: >-
-            A JSON Object of a fatal error encountered during the execution of
-            this task.
-          readOnly: true
-        worker:
-          title: Worker
-          type: string
-          description: >-
-            The worker associated with this task. This field is empty if a
-            worker is not yet assigned.
-          format: uri
-          readOnly: true
-        parent:
-          title: Parent
-          type: string
-          description: The parent task that spawned this task.
-          format: uri
-          readOnly: true
-        spawned_tasks:
-          uniqueItems: true
-          type: array
-          description: Any tasks spawned by this task.
-          readOnly: true
-          items:
-            type: string
-            description: Any tasks spawned by this task.
-            format: uri
-        progress_reports:
-          type: array
-          readOnly: true
-          items:
-            $ref: '#/components/schemas/PulpProgressReport'
-        created_resources:
-          uniqueItems: true
-          type: array
-          description: Resources created by this task.
-          readOnly: true
-          items:
-            type: string
-            description: Resources created by this task.
-            format: uri
+      title: 'Pulp Task'
+      description: 'A Pulp Task'
+      allOf:
+        - $ref: '#/components/schemas/PulpBase'
+        - type: object
+          required:
+            - name
+          properties:
+            state:
+              title: State
+              minLength: 1
+              type: string
+              description: >-
+                The current state of the task. The possible values include:
+                'waiting', 'skipped', 'running', 'completed', 'failed' and
+                'canceled'.
+              readOnly: true
+            name:
+              title: Name
+              minLength: 1
+              type: string
+              description: The name of task.
+            started_at:
+              title: Started at
+              type: string
+              description: Timestamp of the when this task started execution.
+              format: date-time
+              readOnly: true
+            finished_at:
+              title: Finished at
+              type: string
+              description: Timestamp of the when this task stopped execution.
+              format: date-time
+              readOnly: true
+            non_fatal_errors:
+              title: Non fatal errors
+              type: string
+              description: >-
+                A JSON Object of non-fatal errors encountered during the execution
+                of this task.
+              readOnly: true
+            error:
+              title: Error
+              type: string
+              description: >-
+                A JSON Object of a fatal error encountered during the execution of
+                this task.
+              readOnly: true
+            worker:
+              title: Worker
+              type: string
+              description: >-
+                The worker associated with this task. This field is empty if a
+                worker is not yet assigned.
+              format: uri
+              readOnly: true
+            parent:
+              title: Parent
+              type: string
+              description: The parent task that spawned this task.
+              format: uri
+              readOnly: true
+            spawned_tasks:
+              uniqueItems: true
+              type: array
+              description: Any tasks spawned by this task.
+              readOnly: true
+              items:
+                type: string
+                description: Any tasks spawned by this task.
+                format: uri
+            progress_reports:
+              type: array
+              readOnly: true
+              items:
+                $ref: '#/components/schemas/PulpProgressReport'
+            created_resources:
+              uniqueItems: true
+              type: array
+              description: Resources created by this task.
+              readOnly: true
+              items:
+                type: string
+                description: Resources created by this task.
+                format: uri
+
 
     PulpTaskCancel:
       required:
@@ -1792,6 +1840,19 @@ components:
           minLength: 1
           type: string
           description: The desired state of the task. Only 'canceled' is accepted.
+
+    PulpTasksPage:
+      description: "A Page of a list of Pulp Tasks"
+      allOf:
+        - $ref: '#/components/schemas/PageInfo'
+        - type: object
+          properties:
+            results:
+              description: 'List of Pulp Tasks for this Page'
+              title: 'Pulp Tasks'
+              type: array
+              items:
+                $ref: '#/components/schemas/PulpTask'
 
     Role:
       description: 'An Ansible Role'
@@ -2129,6 +2190,20 @@ components:
           schema:
             $ref: '#/components/schemas/ProviderNamespacesPage'
 
+    PulpContentAnsibleCollections:
+      description: "Response from getting pulp collection content"
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PulpContentAnsibleCollectionsPage'
+
+    PulpTasks:
+      description: 'Response containing a Page of a list of Pulp Tasks'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PulpTasksPage'
+
     Roles:
       description: 'Response containing a Page of a list of Roles'
       content:
@@ -2256,6 +2331,14 @@ components:
       schema:
         type: string
 
+    TagId:
+      description: 'Tag id'
+      in: path
+      name: id
+      required: true
+      schema:
+        type: string
+
     UserId:
       description: 'User id'
       in: path
@@ -2287,10 +2370,19 @@ components:
             $ref: '#/components/schemas/ProviderNamespace'
 
   securitySchemes:
-    BasicAuth:
+    # FIXME: kind of faking rbac
+    AdminBasicAuth:
       type: http
       scheme: basic
-    TokenApiKey:
+    UserBasicAuth:
+      type: http
+      scheme: basic
+    UserTokenApiKey:
+      description: Provide a Galaxy API token in "Authorization" header with value in form "Token {api_key}"
+      type: apiKey
+      in: header
+      name: Authorization
+    AdminTokenApiKey:
       description: Provide a Galaxy API token in "Authorization" header with value in form "Token {api_key}"
       type: apiKey
       in: header

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,0 +1,1409 @@
+info:
+  description: 'Galaxy 3.2 API (wip)'
+  title: 'Galaxy 3.2 API (wip)'
+  version: "1.2.0"
+  contact:
+    url: https://github.com/ansible/galaxy/issues
+    name: 'Ansible Galaxy Issues'
+    
+openapi: 3.0.0
+
+servers:
+  - url: https://galaxy.ansible.com/
+    description: 'Production server (uses live data)'
+  - url: https://galaxy-dev.ansible.com/
+    description: 'shared public dev server'
+  - url: http://localhost:8000
+    description: 'local sandbox'
+    
+externalDocs:
+  url: https://galaxy.ansible.com/docs/
+  
+tags:
+  - name: 'collections'
+    externalDocs:
+      url: https://galaxy.ansible.com/docs/contributing/creating_collections.html
+      description: 'Creating Collections docs at galaxy.ansible.com'
+  - name: 'collection-imports'
+  - name: 'collection-versions'
+  - name: 'download'
+  - name: 'client_mazer'
+    description: 'API used by mazer and or ansible-galaxy'
+  - name: 'introspection'
+    description: 'API used to gather information about the API itself'
+  - name: 'v2'
+    description: 'API endpoints from the v2 API'
+  - name: 'notifications'
+  - name: 'me'
+    description: 'API related to the current user.'
+  - name: 'search'
+  - name: 'namespaces'
+  - name: 'tags'
+    description: 'API for Ansible Galaxy tags.'
+  - name: 'users'
+  - name: 'v1'
+    description: 'API endpoints from the v1 API.'
+    
+paths:
+  '/api/':
+    get:
+      summary: 'Get info about the API'
+      operationId: GetAPI
+      tags:
+        - introspection
+      parameters: []
+      responses:
+        '200':
+          description: 'A map of endpoints in the API'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIEndpoints'
+ 
+  '/api/v1/':
+    get:
+      summary: 'Get info about the v1 API'
+      operationId: GetApiV1
+      tags:
+        - introspection
+        - v1
+      parameters: []
+      responses:
+        '200':
+          description: 'A map of endpoints in the v1 API'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIEndpoints'
+                
+  '/api/v1/search/':
+    get:
+      summary: 'Get info about the v1 search API'
+      operationId: GetApiV1Search
+      tags:
+        - search
+        - introspection
+        - v1
+      parameters: []
+      responses:
+        '200':
+          description: 'A map of endpoints in the v1 search API'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIEndpoints'
+                  
+  '/api/v1/me/':
+    get:
+      summary: 'Get the User info for the current user'
+      operationId: GetMeDetail
+      tags:
+        - me
+        - v1
+      parameters:
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          description: 'Response with the current User'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+
+  '/api/v1/namespaces/':
+    get:
+      summary: 'Get a list of Namespaces'
+      operationId: ListNamespaces
+      tags:
+        - namespaces
+        - v1
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          $ref: '#/components/responses/Namespaces'
+          
+  '/api/v1/search/content/':
+    get:
+      summary: 'Get a list of Contents by searching'
+      operationId: ListContentBySearch
+      tags:
+        - search
+        - v1
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+      responses:
+        '200':
+          $ref: '#/components/responses/Contents'
+
+  '/api/v1/search/roles/':
+    get:
+      operationId: ListRoleBySearch
+      tags:
+        - search
+        - v1
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+      responses:
+        '200':
+          $ref: '#/components/responses/Roles'
+          
+  '/api/v1/search/tags/':
+    get:
+      summary: 'Get a list of Tags by searching'
+      operationId: ListTagBySearch
+      tags:
+        - search
+        - v1
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+        # TODO: search param tags
+      responses:
+        '200':
+          $ref: '#/components/responses/Tags'
+          
+  '/api/v1/tags/':
+    get:
+      summary: 'Get a list of Galaxy Tags'
+      operationId: ListTags
+      tags:
+        - tags
+        - v1
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          $ref: '#/components/responses/Tags'
+          
+  '/api/v1/tags/{id}/':
+    get:
+      summary: 'Get a Galaxy Tag'
+      operationId: GetTagById
+      tags:
+        - tags
+        - v1
+      parameters:
+        - description: 'Tag id'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          description: 'A Galaxy Tag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tag'
+  
+  '/api/v1/users/':
+    get:
+      summary: 'Get a list of Users'
+      operationId: ListUsers
+      tags:
+        - users
+        - v1
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          $ref: '#/components/responses/Users'
+
+  '/api/v1/users/{id}/':
+    get:
+      summary: 'Get an User by id'
+      operationId: GetUserById
+      tags:
+        - users
+        - v1
+      parameters:
+        - $ref: '#/components/parameters/UserId'
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          description: 'Response with a User'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+
+    patch:
+      summary: 'Patch/update an User by id'
+      operationId: PatchUserById
+      tags:
+        - users
+        - v1
+      parameters:
+        - $ref: '#/components/parameters/UserId'
+        - $ref: '#/components/parameters/Search'
+      requestBody:
+        description: 'An User to update to'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserUpdate'
+
+      responses:
+        '200':
+          description: 'The User updated by the PATCH'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+
+  '/api/v2/collection-imports/{id}/':
+    get:
+      summary: 'Get a Collection-Import (import task) by id'
+      operationId: GetCollectionImportById
+      tags:
+        - collection-imports
+        - v2
+      parameters:
+        - description: 'A unique integer value identifying this collection import.'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          description: 'The result of a collection import'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CollectionImportResult'
+                
+  '/api/v2/collection-versions/{id}/artifact/':
+    get:
+      operationId: GetCollectionVersionArtifactById
+      tags:
+        - collection-versions
+        - v2
+      parameters:
+        - description: 'The CollectionVersion id'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          $ref: '#/components/responses/CollectionVersionArtifact'
+
+  '/api/v2/collection-versions/{version_pk}/':
+    get:
+      summary: 'Get a CollectionVersion by version_pk'
+      operationId: GetCollectionVersionByVersionPk
+      tags:
+        - collection-versions
+        - v2
+      parameters:
+        - description: 'The CollectionVersion version_pk'
+          in: path
+          name: version_pk
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/CollectionVersion'
+                
+  '/api/v2/collections/':
+    post:
+      summary: 'Create a new CollectionVersion by importing a collection artifact'
+      operationId: ImportCollectionVersionArtifact
+      tags:
+        - collections
+        - v2
+        - client_mazer
+      parameters: []
+      requestBody:
+        $ref: '#/components/requestBodies/CollectionVersionArtifactBody'
+      responses:
+        '202':
+          $ref: '#/components/responses/CreateCollectionResult'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
+          
+  '/api/v2/collections/{id}/':
+    get:
+      summary: 'Get a Collection by id'
+      operationId: GetCollectionById
+      tags:
+        - collections
+        - v2
+      parameters:
+        - $ref: '#/components/parameters/CollectionId'
+      responses:
+        '200':
+          description: 'A Collection'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+
+  '/api/v2/collections/{id}/versions/':
+    get:
+      summary: 'Get list of versions for a collection id'
+      operationId: ListCollectionVersionsById
+      tags:
+        - collections
+        - v2
+      parameters:
+        - $ref: '#/components/parameters/CollectionId'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          $ref: '#/components/responses/CollectionVersions'
+          
+  '/api/v2/collections/{namespace}/{name}/':
+    parameters:
+      - $ref: '#/components/parameters/CollectionNamespace'
+      - $ref: '#/components/parameters/CollectionName'
+    get:
+      summary: 'Get a Collection by namespace and name'
+      operationId: GetCollectionByNamespaceName
+      tags:
+        - collections
+        - v2
+        - client_mazer
+      responses:
+        '200':
+          description: 'A Collection'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+                
+  '/api/v2/collections/{namespace}/{name}/versions/':
+    parameters:
+      - $ref: '#/components/parameters/CollectionNamespace'
+      - $ref: '#/components/parameters/CollectionName'
+    get:
+      summary: 'Get a list of CollectionVersions for a Collection by namespace and name'
+      operationId: ListCollectionVersionsByNamespaceName
+      tags:
+        - collections
+        - v2
+        - client_mazer
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          $ref: '#/components/responses/CollectionVersions'
+          
+  '/api/v2/collections/{namespace}/{name}/versions/{version}/':
+    parameters:
+      - $ref: '#/components/parameters/CollectionNamespace'
+      - $ref: '#/components/parameters/CollectionName'
+      - $ref: '#/components/parameters/CollectionVersion'
+    get:
+      summary: 'Get a CollectionVersion by namespace, name, and version'
+      operationId: GetCollectionVersion
+      tags:
+        - collections
+        - v2
+        - client_mazer
+      responses:
+        '200':
+          $ref: '#/components/responses/CollectionVersion'
+                
+  '/api/v2/collections/{namespace}/{name}/versions/{version}/artifact/':
+    parameters:
+      - $ref: '#/components/parameters/CollectionNamespace'
+      - $ref: '#/components/parameters/CollectionName'
+      - $ref: '#/components/parameters/CollectionVersion'
+    get:
+      summary: 'Get Artifact details for a Collection by namespace, name, and version'
+      operationId: GetCollectionVersionArtifact
+      tags:
+        - collections
+        - v2
+        - client_mazer
+      parameters:
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          $ref: '#/components/responses/CollectionVersionArtifact'
+
+  '/download/{filename}':
+    get:
+      summary: 'Download the collection artifact'
+      operationId: DownloadArtifactByFilename
+      tags:
+        - download
+        - client_mazer
+      parameters:
+        - description: 'CollectionVersion artifact filename'
+          in: path
+          name: filename
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'The collection artifact file binary contents'
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+
+components:
+  schemas:
+    Error:
+      type: object
+      description: 'Error data'
+      properties:
+        code:
+          description: 'Unique identifier for the error'
+          type: string
+          example: 'invalid'
+        message:
+          type: string
+          example: 'namespace and name parameters are required'
+        field:
+          description: 'The name of the field involved'
+          type: string
+          example: 'namespace'
+      required:
+        - code
+        - message
+        
+    APIException:
+      type: object
+      description: 'API Exception'
+      properties:
+        code:
+          description: 'Unique identifier for the exception'
+          type: string
+          example: 'not_authenticated'
+        message:
+          type: string
+          example: 'Authentication credentials were not provided.'
+        errors:
+          description: 'A list of additional error objects'
+          type: array
+          items:
+            $ref: '#/components/schemas/Error'
+      required:
+        - code
+        - message
+        
+    ConflictError:
+      allOf:
+        - $ref: '#/components/schemas/APIException'
+        
+    ConflictCollectionExistsError:
+      allOf:
+        - $ref: '#/components/schemas/ConflictError'
+        
+    RepositoryNameError:
+      allOf:
+        - $ref: '#/components/schemas/ConflictError'
+        
+    ArtifactExistsError:
+      allOf:
+        - $ref: '#/components/schemas/ConflictError'
+        
+    ValidationError:
+      allOf:
+        - $ref: '#/components/schemas/APIException'
+        
+    APIEndpoints:
+      description: 'Map of API endpoint names to URLS'
+      type: object
+      additionalProperties:
+        type: string
+        
+    PageCount:
+      type: integer
+      
+    PageNext:
+      type: string
+      
+    PagePrevious:
+      type: string
+      
+    CollectionVersionLink:
+      type: object
+      properties:
+        href:
+          description: 'The URL to the CollectionVersion'
+          type: string
+        version:
+          type: string
+          maxLength: 64
+
+    CollectionVersionArtifactDetail:
+      type: object
+      properties:
+        download_url:
+          readOnly: true
+          type: string
+        filename:
+          readOnly: true
+          type: string
+        sha256:
+          type: string
+        size:
+          type: integer
+          
+    CollectionName:
+      description: 'The name of a Collection'
+      type: string
+      example: 'my_collection'
+      pattern: '^(?!.*__)[a-z]+[0-9a-z_]*$'
+      
+    CollectionNamespaceName:
+      description: 'The Collection namespace'
+      type: string
+      example: 'my_namespace'
+      pattern: '^(?!.*__)[a-z]+[0-9a-z_]*$'
+      
+    Collection:
+      description: 'An Ansible Collection'
+      type: object
+      properties:
+        latest_version:
+          $ref: '#/components/schemas/CollectionVersionLink'
+        created:
+          type: string
+          readOnly: true
+        deprecated:
+          type: boolean
+        name:
+          type: string
+        namespace:
+          $ref: '#/components/schemas/CollectionNamespace'
+        modified:
+          type: string
+          readOnly: true
+        id:
+          type: integer
+          readOnly: true
+        href:
+          type: string
+          format: uri
+        versions_url:
+          type: string
+          
+    CollectionImportError:
+      type: object
+      properties:
+        code:
+          type: string
+        description:
+          type: string
+        traceback:
+          type: string
+          
+    CollectionImportMessage:
+      description: 'Message from collection importer including lint results'
+
+      type: object
+      properties:
+        level:
+          type: string
+        message:
+          type: string
+        time:
+          type: string
+          format: date-time
+      required:
+        - level
+        - message
+        - time
+          
+    CollectionImportLintRecord:
+      description: 'Records from collection linters'
+      type: object
+      properties:
+        code:
+          type: string
+        type:
+          type: string
+        message:
+          type: string
+        severity:
+          type: integer
+        score_type:
+          type: string
+          nullable: true
+
+    CollectionCreationResult:
+      description: 'A map of collection import task info, including its url'
+      type: object
+      properties:
+        task:
+          description: 'The url for the queued collection import task. Check it for progress and status.'
+          type: string
+          format: uri
+          
+    CollectionImportResult:
+      description: 'Collection import result'
+      type: object
+      properties:
+        error:
+          $ref: '#/components/schemas/CollectionImportError'
+        finished_at:
+          type: string
+          format: date-time
+        id:
+          type: integer
+        imported_version:
+          type: string
+          readOnly: true
+        job_id:
+          type: string
+          format: uuid
+        lint_records:
+          type: array
+          items:
+            $ref: '#/components/schemas/CollectionImportLintRecord'
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/CollectionImportMessage'
+        name:
+          maxLength: 64
+          type: string
+        namespace:
+          type: string
+        started_at:
+          type: string
+          format: date-time
+        state:
+          type: string
+        version:
+          maxLength: 64
+          type: string
+      required:
+        - error
+        - finished_at
+        - id
+        - job_id
+        - lint_records
+        - messages
+        - name
+        - namespace
+        - started_at
+        - state
+        - version
+          
+    CollectionNamespace:
+      type: object
+      properties:
+        name:
+          $ref: '#/components/schemas/CollectionNamespaceName'
+        id:
+          type: integer
+        href:
+          description: 'link to the Namespace'
+          type: string
+          format: uri
+          
+    CollectionVersionDetailCollection:
+      type: object
+      properties:
+        name:
+          type: string
+        id:
+          type: integer
+        href:
+          description: 'link to the Collection'
+          type: string
+          format: uri
+          
+    CollectionVersionDetailArtifact:
+      type: object
+      properties:
+        filename:
+          type: string
+        size:
+          type: integer
+        sha256:
+          type: string
+          
+    SemanticVersion:
+      description: 'A version string in the Semantic Version form'
+      type: string
+      example: '1.0.1'
+      
+    SemanticVersionSpec:
+      description: 'A string to match against SemanticVersion'
+      type: string
+      example: '>=1.0.0'
+      
+    CollectionVersionDependencies:
+      description: 'A map of collection namespace.name to a semantic version'
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/SemanticVersionSpec'
+      
+    CollectionVersionLicense:
+      description: 'A SPDX license id'
+      type: string
+      # TODO: This could in theory be an enum
+        
+    GalaxyTag:
+      description: 'A Galaxy Tag'
+      type: string
+      pattern: '^[a-z0-9]+$'
+      example: 'development'
+        
+    Author:
+      description: 'Author of a collection or role'
+      type: string
+      format: email
+      # TODO: add author validation pattern
+      example: 'Adrian Likins <alikins@redhat.com>'
+      
+    CollectionVersionDetailMetadata:
+      description: "The Collection Version metadata from collections galaxy.yml or MANIFEST.JSON"
+      type: object
+      properties:
+        documentation:
+          description: 'Documentation URL'
+          type: string
+          format: uri
+          nullable: true
+        description:
+          description: 'Description of the collection'
+          type: string
+          nullable: true
+        readme:
+          description: 'Name of file to use for README'
+          type: string
+          format: relative-file-path
+        repository:
+          description: 'SCM repository for collection'
+          type: string
+          format: uri
+          nullable: true
+        issues:
+          description: 'URL of issues or bug tracking'
+          type: string
+          format: uri
+          nullable: true
+        version:
+          $ref: '#/components/schemas/SemanticVersion'
+        license_file:
+          description: 'Name of file where license info can be found'
+          type: string
+          format: relative-file-path
+          nullable: true
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/GalaxyTag'
+        dependencies:
+          $ref: '#/components/schemas/CollectionVersionDependencies'
+        license:
+          description: 'A list of SPDX license ids'
+          type: array
+          items:
+            $ref: '#/components/schemas/CollectionVersionLicense'
+        name:
+          $ref: '#/components/schemas/CollectionName'
+        namespace:
+          $ref: '#/components/schemas/CollectionNamespaceName'
+        authors:
+          description: 'A list of collection authors'
+          type: array
+          items:
+            $ref: '#/components/schemas/Author'
+        homepage:
+          type: string
+          format: uri
+      required:
+        - namespace
+        - name
+        - version
+        
+    CollectionVersion:
+      type: object
+      properties:
+        artifact:
+          $ref: '#/components/schemas/CollectionVersionDetailArtifact'   
+        metadata:
+          $ref: '#/components/schemas/CollectionVersionDetailMetadata'
+        hidden:
+          type: boolean
+        download_url:
+          type: string
+          format: uri
+        namespace:
+          $ref: '#/components/schemas/CollectionNamespace'
+        id:
+          type: integer
+        href:
+          type: string
+          format: uri
+        collection:
+          $ref: '#/components/schemas/CollectionVersionDetailCollection'
+
+    CollectionVersionArtifactData:
+      description: 'CollectionVersionArtifact archive file binary and sha256 checksum. Used for importing collection artifacts'
+      type: object 
+      properties:
+        sha256:
+          description: 'The sha256sum of the collection artifact file'
+          type: string
+        file:
+          description: 'The binary contents of a collection artifact'
+          type: string
+          format: binary
+                
+    V1BaseModel:
+      description: 'Base for common v1 shared model attributes' 
+      type: object
+      properties:
+        id:
+          description: 'Database ID for this object.'
+          readOnly: true
+          type: integer
+        url:
+          description: 'URL for this resource.'
+          readOnly: true
+          type: string
+          format: uri
+        related:
+          description: 'Data structure with URLs of related resources.'
+          readOnly: true
+          type: object
+          additionalProperties:
+            type: string
+        summary_fields:
+          description: >-
+            Data structure with name/description for related
+            resources.
+          readOnly: true
+          type: object
+          additionalProperties: {}
+        active:
+          readOnly: true
+          type: string
+        modified:
+          description: 'Timestamp when this object was last modified.'
+          readOnly: true
+          type: string
+        created:
+          description: 'Timestamp when this object was created.'
+          readOnly: true
+          type: string
+      required:
+        - id
+        
+      
+    Content:
+      allOf:
+        - $ref: '#/components/schemas/V1BaseModel'
+        - type: object
+          properties:
+            company:
+              maxLength: 50
+              nullable: true
+              type: string
+            description:
+              maxLength: 255
+              type: string
+            download_count:
+              readOnly: true
+              type: string
+            download_rank:
+              type: number
+            imported:
+              format: date-time
+              nullable: true
+              type: string
+            is_valid:
+              readOnly: true
+              type: boolean
+            license:
+              maxLength: 50
+              type: string
+            min_ansible_version:
+              maxLength: 10
+              nullable: true
+              type: string
+            name:
+              maxLength: 512
+              type: string
+            relevance:
+              type: number
+            role_type:
+              readOnly: true
+              type: string
+            search_rank:
+              type: number
+            travis_status_url:
+              readOnly: true
+              type: string
+            username:
+              readOnly: true
+              type: string
+          required:
+            - name
+            - relevance
+            - search_rank
+            - download_rank
+          
+    Namespace:
+      description: 'A Namespace'
+      allOf:
+        - $ref: '#/components/schemas/V1BaseModel'      
+        - type: object
+          properties:
+            avatar_url:
+              maxLength: 256
+              nullable: true
+              type: string
+            company:
+              maxLength: 256
+              nullable: true
+              type: string
+            description:
+              maxLength: 255
+              type: string
+            email:
+              maxLength: 256
+              nullable: true
+              type: string
+            html_url:
+              maxLength: 256
+              nullable: true
+              type: string
+            is_vendor:
+              type: boolean
+            location:
+              maxLength: 256
+              nullable: true
+              type: string
+            name:
+              maxLength: 512
+              type: string
+          required:
+            - name
+        
+    Role:
+      description: 'An Ansible Role'
+      allOf:
+        - $ref: '#/components/schemas/V1BaseModel'  
+        - type: object
+          properties:
+            company:
+              maxLength: 50
+              nullable: true
+              type: string
+            description:
+              maxLength: 255
+              type: string
+            download_count:
+              readOnly: true
+              type: string
+            download_rank:
+              type: number
+            imported:
+              format: date-time
+              nullable: true
+              type: string
+            is_valid:
+              readOnly: true
+              type: boolean
+            license:
+              maxLength: 50
+              type: string
+            min_ansible_version:
+              maxLength: 10
+              nullable: true
+              type: string
+            name:
+              maxLength: 512
+              type: string
+            relevance:
+              type: number
+            role_type:
+              readOnly: true
+              type: string
+            search_rank:
+              type: number
+            travis_status_url:
+              readOnly: true
+              type: string
+            username:
+              readOnly: true
+              type: string
+          required:
+            - name
+            - relevance
+            - search_rank
+            - download_rank
+
+    Tag:
+      description: 'A v1 galaxy Tag'
+      allOf:
+        - $ref: '#/components/schemas/V1BaseModel'  
+        - type: object
+          properties:
+            name:
+              maxLength: 512
+              type: string
+          required:
+            - name
+        
+    User:
+      description: 'A v1 User'
+      allOf:
+        - $ref: '#/components/schemas/V1BaseModel' 
+        - type: object
+          properties:
+            avatar_url:
+              maxLength: 256
+              type: string
+            date_joined:
+              format: date-time
+              type: string
+            full_name:
+              maxLength: 254
+              type: string
+            staff:
+              readOnly: true
+              type: string
+            username:
+              description: >-
+                Required. 30 characters or fewer. Letters, numbers and
+                @/./+/-/_ characters
+              maxLength: 30
+              pattern: '^[a-zA-Z0-9_.@+-]+$'
+              type: string
+          required:
+            - username
+        
+    UserUpdate:
+      description: 'User data to update'
+      properties:
+        avatar_url:
+          maxLength: 256
+          type: string
+        date_joined:
+          format: date-time
+          type: string
+        full_name:
+          maxLength: 254
+          type: string
+        username:
+          description: >-
+            Required. 30 characters or fewer. Letters, numbers and
+            @/./+/-/_ characters
+          maxLength: 30
+          pattern: '^[a-zA-Z0-9_.@+-]+$'
+          type: string
+
+    # Instead of creating a schema type for each paginated
+    # might be able to make 'results' a PageResults type.
+    # And make PageResults use 'anyOf' and a discriminator
+    # to 'choose' the correct type in the list. But currently
+    # there isn't info in the Page data that indicates the
+    # type to be expected in the 'results'. This would need
+    # something like a 'result_type': 'CollectionVersion' in
+    # the data.
+    CollectionVersionsPage:
+      description: 'A page of a list of CollectionVersionLinks'
+      type: object
+      properties:
+        count:
+          $ref: '#/components/schemas/PageCount'
+        next:
+          $ref: '#/components/schemas/PageNext'
+        previous:
+          $ref: '#/components/schemas/PagePrevious'
+        results:
+          description: 'List of CollectionVersionLinks for this Page'
+          type: array
+          items:
+            $ref: '#/components/schemas/CollectionVersionLink'
+            
+    ContentsPage:
+      description: "A page of a list of Contents"
+      type: object
+      properties:
+        count:
+          $ref: '#/components/schemas/PageCount'
+        next:
+          $ref: '#/components/schemas/PageNext'
+        previous:
+          $ref: '#/components/schemas/PagePrevious'
+        results:
+          description: 'List of Contents for this Page'
+          type: array
+          items:
+            $ref: '#/components/schemas/Content'
+            
+    NamespacesPage:
+      description: "A Page of a list of Namespaces"
+      type: object
+      properties:
+        count:
+          $ref: '#/components/schemas/PageCount'
+        next:
+          $ref: '#/components/schemas/PageNext'
+        previous:
+          $ref: '#/components/schemas/PagePrevious'
+        results:
+          description: 'List of Namespaces for this Page'
+          type: array
+          items:
+            $ref: '#/components/schemas/Namespace' 
+            
+    RolesPage:
+      description: "A Page of a list of Roles"
+      type: object
+      properties:
+        count:
+          $ref: '#/components/schemas/PageCount'
+        next:
+          $ref: '#/components/schemas/PageNext'
+        previous:
+          $ref: '#/components/schemas/PagePrevious'
+        results:
+          description: 'List of Roles for this Page'
+          type: array
+          items:
+            $ref: '#/components/schemas/Role' 
+            
+    TagsPage:
+      description: "A page of a list of Galaxy Tags"
+      type: object
+      properties:
+        count:
+          $ref: '#/components/schemas/PageCount'
+        next:
+          $ref: '#/components/schemas/PageNext'
+        previous:
+          $ref: '#/components/schemas/PagePrevious'
+        results:
+          description: 'List of Tags for this Page'
+          type: array
+          items:
+            $ref: '#/components/schemas/Tag'
+            
+    UsersPage:
+      description: "A page of a list of Users"
+      type: object
+      properties:
+        count:
+          $ref: '#/components/schemas/PageCount'
+        next:
+          $ref: '#/components/schemas/PageNext'
+        previous:
+          $ref: '#/components/schemas/PagePrevious'
+        results:
+          description: 'List of Users for this Page'
+          type: array
+          items:
+            $ref: '#/components/schemas/User'
+
+
+  responses:
+    Conflict:
+      description: 'Conflict Error'
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/ConflictError'
+            discriminator:
+              propertyName: code
+              mapping:
+                conflict: '#/components/schemas/ConflictError'
+                conflict.collection_exists: '#/components/schemas/ConflictCollectionExistsError'
+                conflict.repository_name_conflict: '#/compontents/schemas/RepositoryNameError'
+                conflict.artifact_exists: '#/compontents/schemas/ArtifactExistsError'
+                
+    Unauthorized:
+      description: 'Authorization error'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/APIException'
+
+    CollectionVersions:
+      description: 'Response containing a page of CollectionVersionLinks'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CollectionVersionsPage'
+
+    CollectionVersion:
+      description: 'Response contain a CollectionVersion'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CollectionVersion'
+      links:
+        GetCollectionVersionById:
+          operationId: GetCollectionVersionById
+          parameters:
+            id: '$response.body#/id'
+          description: >
+            The `id` value returned in the response can be used as
+            the `id` parameter in `{method} GET /api/v2/collection-versions/{id}`.
+        GetCollectionById:
+          operationId: GetCollectionById
+          parameters:
+            id: '$response.body#/collection/id'
+        DownloadArtifactByFilename:
+          operationId: DownloadArtifactByFilename
+          parameters:
+            id: '$response.body#/artifact/filename'
+          description: >
+            The `filename` value returned in the response can be used as
+            the `filename` parameter in `GET /download/{filename}`.
+
+    CollectionVersionArtifact:
+      description: 'The collection version artifact details with download_url, sha256, and filename'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CollectionVersionArtifactDetail'
+
+    CreateCollectionResult:
+      description: 'Result of collection import task with task url'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CollectionCreationResult'
+            
+    Contents:
+      description: 'Response containing a Page of Content search results'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ContentsPage'
+            
+    Users:
+      description: 'Response containing a Page of a list of Users'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UsersPage'
+            
+    Namespaces:
+      description: 'Response containing a Page of a list of Namespaces'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/NamespacesPage'
+            
+    Roles:
+      description: 'Response containing a Page of a list of Roles'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/RolesPage'
+     
+    Tags:
+      description: 'Response containing a Page of a list of Tags'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TagsPage'
+
+  parameters:
+    Page:
+      description: 'Page number within the paginated result set.'
+      in: query
+      name: page
+      required: false
+      schema:
+        type: integer
+        default: 1
+        
+    PageSize:
+      description: 'Number of results to return per page.'
+      in: query
+      name: page_size
+      required: false
+      schema:
+        type: integer
+        default: 10
+        minimum: 0
+        maximum: 1000
+        
+    Search:
+      description: 'Term to search for'
+      in: query
+      name: search
+      required: false
+      schema:
+        type: string
+        
+    CollectionId:
+      description: 'The Collection id'
+      in: path
+      name: id
+      required: true
+      schema:
+        type: string
+        
+    CollectionNamespace:
+      description: 'The collection namespace'
+      in: path
+      name: namespace
+      required: true
+      schema:
+        type: string
+        
+    CollectionName:
+      description: 'The collection name'
+      in: path
+      name: name
+      required: true
+      schema:
+        type: string
+        pattern: ^(?!.*__)[a-z]+[0-9a-z_]*$'
+        
+    CollectionVersion:
+      description: 'A Semantic Version string'
+      in: path
+      name: version
+      required: true
+      schema:
+        type: string
+        pattern: ^((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$
+        
+    UserId:
+      description: 'User id'
+      in: path
+      name: id
+      required: true
+      schema:
+        type: string
+        
+  requestBodies:
+    CollectionVersionArtifactBody:
+      description: "A multipart/form encoded payload including the binary collection artifact file contents and it's sha256sum"
+      content:
+        multipart/form-data:
+          schema:
+            $ref: '#/components/schemas/CollectionVersionArtifactData'

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -334,6 +334,105 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/CollectionVersionArtifact'
+  '/content/ansible/collections/':
+    get:
+      tags:
+        - collections
+        - pulp
+        - v3
+      summary: List collections
+      description: |
+        Wrapper for https://pulp-ansible.readthedocs.io/en/latest/restapi.html#operation/content_ansible_collections_list
+      operationId: GetPulpContentAnsibleCollections
+      parameters:
+      - name: name
+        in: query
+        description: Filter results where name matches value
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        description: Filter results where namespace matches value
+        schema:
+          type: string
+      - name: version
+        in: query
+        description: Filter results where version matches value
+        schema:
+          type: string
+      - name: repository_version
+        in: query
+        description: Repository Version referenced by HREF
+        schema:
+          type: string
+      - name: repository_version_added
+        in: query
+        description: Repository Version referenced by HREF
+        schema:
+          type: string
+      - name: repository_version_removed
+        in: query
+        description: Repository Version referenced by HREF
+        schema:
+          type: string
+      - name: page
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      responses:
+        200:
+          description: "response from getting pulp collection content"
+          content:
+            application/json:
+              schema:
+                required:
+                - count
+                - results
+                type: object
+                properties:
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  count:
+                    type: integer
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PulpCollection'
+    post:
+      summary: Create a collection
+      description: |
+        ViewSet for Ansible Collection.
+        Wrapper for https://pulp-ansible.readthedocs.io/en/latest/restapi.html#operation/content_ansible_collections_create
+      operationId: content_ansible_collections_create
+      tags:
+        - pulp
+        - collections
+        - v3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PulpCollection'
+        required: true
+      responses:
+        201:
+          description: ""
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PulpCollection'
 
   '/download/{filename}':
     get:
@@ -1276,6 +1375,49 @@ components:
           required:
             - results
 
+    PulpCollection:
+      title: 'PulpCollection'
+      description: 'A Collection as stored in Pulp'
+      required:
+        - _artifact
+        - name
+        - namespace
+        - version
+      type: object
+      properties:
+        _href:
+          title: ' href'
+          type: string
+          format: uri
+          readOnly: true
+        _type:
+          title: ' type'
+          minLength: 1
+          type: string
+          readOnly: true
+        _artifact:
+          title: ' artifact'
+          type: string
+          description: Artifact file representing the physical content
+          format: uri
+        _created:
+          title: ' created'
+          type: string
+          description: Timestamp of creation.
+          format: date-time
+          readOnly: true
+        version:
+          title: Version
+          minLength: 1
+          type: string
+        name:
+          title: Name
+          minLength: 1
+          type: string
+        namespace:
+          title: Namespace
+          minLength: 1
+          type: string
     Role:
       description: 'An Ansible Role'
       title: 'Role'

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -589,24 +589,12 @@ paths:
 
 components:
   schemas:
-    Error:
+
+    APIEndpoints:
+      description: 'Map of API endpoint names to URLS'
       type: object
-      description: 'Error data'
-      properties:
-        code:
-          description: 'Unique identifier for the error'
-          type: string
-          example: 'invalid'
-        message:
-          type: string
-          example: 'namespace and name parameters are required'
-        field:
-          description: 'The name of the field involved'
-          type: string
-          example: 'namespace'
-      required:
-        - code
-        - message
+      additionalProperties:
+        type: string
 
     APIException:
       type: object
@@ -628,76 +616,16 @@ components:
         - code
         - message
 
-    ConflictError:
-      allOf:
-        - $ref: '#/components/schemas/APIException'
-
-    ConflictCollectionExistsError:
-      allOf:
-        - $ref: '#/components/schemas/ConflictError'
-
-    RepositoryNameError:
-      allOf:
-        - $ref: '#/components/schemas/ConflictError'
-
     ArtifactExistsError:
       allOf:
         - $ref: '#/components/schemas/ConflictError'
 
-    ValidationError:
-      allOf:
-        - $ref: '#/components/schemas/APIException'
-
-    APIEndpoints:
-      description: 'Map of API endpoint names to URLS'
-      type: object
-      additionalProperties:
-        type: string
-
-    PageCount:
-      type: integer
-
-    PageNext:
+    Author:
+      description: 'Author of a collection or role'
       type: string
-
-    PagePrevious:
-      type: string
-
-    CollectionVersionLink:
-      type: object
-      properties:
-        href:
-          description: 'The URL to the CollectionVersion'
-          type: string
-        version:
-          type: string
-          maxLength: 64
-
-    CollectionVersionArtifactDetail:
-      type: object
-      properties:
-        download_url:
-          readOnly: true
-          type: string
-        filename:
-          readOnly: true
-          type: string
-        sha256:
-          type: string
-        size:
-          type: integer
-
-    CollectionName:
-      description: 'The name of a Collection'
-      type: string
-      example: 'my_collection'
-      pattern: '^(?!.*__)[a-z]+[0-9a-z_]*$'
-
-    CollectionNamespaceName:
-      description: 'The Collection namespace'
-      type: string
-      example: 'my_namespace'
-      pattern: '^(?!.*__)[a-z]+[0-9a-z_]*$'
+      format: email
+      # TODO: add author validation pattern
+      example: 'Adrian Likins <alikins@redhat.com>'
 
     Collection:
       description: 'An Ansible Collection'
@@ -828,6 +756,18 @@ components:
         - state
         - version
 
+    CollectionName:
+      description: 'The name of a Collection'
+      type: string
+      example: 'my_collection'
+      pattern: '^(?!.*__)[a-z]+[0-9a-z_]*$'
+
+    CollectionNamespaceName:
+      description: 'The Collection namespace'
+      type: string
+      example: 'my_namespace'
+      pattern: '^(?!.*__)[a-z]+[0-9a-z_]*$'
+
     CollectionNamespace:
       type: object
       properties:
@@ -840,17 +780,59 @@ components:
           type: string
           format: uri
 
-    CollectionVersionDetailCollection:
+    CollectionVersion:
       type: object
       properties:
-        name:
+        artifact:
+          $ref: '#/components/schemas/CollectionVersionDetailArtifact'
+        metadata:
+          $ref: '#/components/schemas/CollectionVersionDetailMetadata'
+        hidden:
+          type: boolean
+        download_url:
           type: string
+          format: uri
+        namespace:
+          $ref: '#/components/schemas/CollectionNamespace'
         id:
           type: integer
         href:
-          description: 'link to the Collection'
           type: string
           format: uri
+        collection:
+          $ref: '#/components/schemas/CollectionVersionDetailCollection'
+
+    CollectionVersionArtifactData:
+      description: 'CollectionVersionArtifact archive file binary and sha256 checksum. Used for importing collection artifacts'
+      type: object
+      properties:
+        sha256:
+          description: 'The sha256sum of the collection artifact file'
+          type: string
+        file:
+          description: 'The binary contents of a collection artifact'
+          type: string
+          format: binary
+
+    CollectionVersionArtifactDetail:
+      type: object
+      properties:
+        download_url:
+          readOnly: true
+          type: string
+        filename:
+          readOnly: true
+          type: string
+        sha256:
+          type: string
+        size:
+          type: integer
+
+    CollectionVersionDependencies:
+      description: 'A map of collection namespace.name to a semantic version'
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/SemanticVersionSpec'
 
     CollectionVersionDetailArtifact:
       type: object
@@ -862,39 +844,17 @@ components:
         sha256:
           type: string
 
-    SemanticVersion:
-      description: 'A version string in the Semantic Version form'
-      type: string
-      example: '1.0.1'
-
-    SemanticVersionSpec:
-      description: 'A string to match against SemanticVersion'
-      type: string
-      example: '>=1.0.0'
-
-    CollectionVersionDependencies:
-      description: 'A map of collection namespace.name to a semantic version'
+    CollectionVersionDetailCollection:
       type: object
-      additionalProperties:
-        $ref: '#/components/schemas/SemanticVersionSpec'
-
-    CollectionVersionLicense:
-      description: 'A SPDX license id'
-      type: string
-      # TODO: This could in theory be an enum
-
-    GalaxyTag:
-      description: 'A Galaxy Tag'
-      type: string
-      pattern: '^[a-z0-9]+$'
-      example: 'development'
-
-    Author:
-      description: 'Author of a collection or role'
-      type: string
-      format: email
-      # TODO: add author validation pattern
-      example: 'Adrian Likins <alikins@redhat.com>'
+      properties:
+        name:
+          type: string
+        id:
+          type: integer
+        href:
+          description: 'link to the Collection'
+          type: string
+          format: uri
 
     CollectionVersionDetailMetadata:
       description: "The Collection Version metadata from collections galaxy.yml or MANIFEST.JSON"
@@ -958,80 +918,52 @@ components:
         - name
         - version
 
-    CollectionVersion:
+    CollectionVersionLicense:
+      description: 'A SPDX license id'
+      type: string
+      # TODO: This could in theory be an enum
+
+    CollectionVersionLink:
       type: object
       properties:
-        artifact:
-          $ref: '#/components/schemas/CollectionVersionDetailArtifact'
-        metadata:
-          $ref: '#/components/schemas/CollectionVersionDetailMetadata'
-        hidden:
-          type: boolean
-        download_url:
-          type: string
-          format: uri
-        namespace:
-          $ref: '#/components/schemas/CollectionNamespace'
-        id:
-          type: integer
         href:
+          description: 'The URL to the CollectionVersion'
           type: string
-          format: uri
-        collection:
-          $ref: '#/components/schemas/CollectionVersionDetailCollection'
+        version:
+          type: string
+          maxLength: 64
 
-    CollectionVersionArtifactData:
-      description: 'CollectionVersionArtifact archive file binary and sha256 checksum. Used for importing collection artifacts'
+    # Instead of creating a schema type for each paginated
+    # might be able to make 'results' a PageResults type.
+    # And make PageResults use 'anyOf' and a discriminator
+    # to 'choose' the correct type in the list. But currently
+    # there isn't info in the Page data that indicates the
+    # type to be expected in the 'results'. This would need
+    # something like a 'result_type': 'CollectionVersion' in
+    # the data.
+    CollectionVersionsPage:
+      description: 'A page of a list of CollectionVersionLinks'
       type: object
       properties:
-        sha256:
-          description: 'The sha256sum of the collection artifact file'
-          type: string
-        file:
-          description: 'The binary contents of a collection artifact'
-          type: string
-          format: binary
+        count:
+          $ref: '#/components/schemas/PageCount'
+        next:
+          $ref: '#/components/schemas/PageNext'
+        previous:
+          $ref: '#/components/schemas/PagePrevious'
+        results:
+          description: 'List of CollectionVersionLinks for this Page'
+          type: array
+          items:
+            $ref: '#/components/schemas/CollectionVersionLink'
 
-    V1BaseModel:
-      description: 'Base for common v1 shared model attributes'
-      type: object
-      properties:
-        id:
-          description: 'Database ID for this object.'
-          readOnly: true
-          type: integer
-        url:
-          description: 'URL for this resource.'
-          readOnly: true
-          type: string
-          format: uri
-        related:
-          description: 'Data structure with URLs of related resources.'
-          readOnly: true
-          type: object
-          additionalProperties:
-            type: string
-        summary_fields:
-          description: >-
-            Data structure with name/description for related
-            resources.
-          readOnly: true
-          type: object
-          additionalProperties: {}
-        active:
-          readOnly: true
-          type: string
-        modified:
-          description: 'Timestamp when this object was last modified.'
-          readOnly: true
-          type: string
-        created:
-          description: 'Timestamp when this object was created.'
-          readOnly: true
-          type: string
-      required:
-        - id
+    ConflictError:
+      allOf:
+        - $ref: '#/components/schemas/APIException'
 
+    ConflictCollectionExistsError:
+      allOf:
+        - $ref: '#/components/schemas/ConflictError'
 
     Content:
       allOf:
@@ -1086,6 +1018,47 @@ components:
             - search_rank
             - download_rank
 
+    ContentsPage:
+      description: "A page of a list of Contents"
+      type: object
+      properties:
+        count:
+          $ref: '#/components/schemas/PageCount'
+        next:
+          $ref: '#/components/schemas/PageNext'
+        previous:
+          $ref: '#/components/schemas/PagePrevious'
+        results:
+          description: 'List of Contents for this Page'
+          type: array
+          items:
+            $ref: '#/components/schemas/Content'
+
+    Error:
+      type: object
+      description: 'Error data'
+      properties:
+        code:
+          description: 'Unique identifier for the error'
+          type: string
+          example: 'invalid'
+        message:
+          type: string
+          example: 'namespace and name parameters are required'
+        field:
+          description: 'The name of the field involved'
+          type: string
+          example: 'namespace'
+      required:
+        - code
+        - message
+
+    GalaxyTag:
+      description: 'A Galaxy Tag'
+      type: string
+      pattern: '^[a-z0-9]+$'
+      example: 'development'
+
     Namespace:
       description: 'A Namespace'
       allOf:
@@ -1123,6 +1096,39 @@ components:
           required:
             - name
 
+    NamespacesPage:
+      description: "A Page of a list of Namespaces"
+      type: object
+      properties:
+        count:
+          $ref: '#/components/schemas/PageCount'
+        next:
+          $ref: '#/components/schemas/PageNext'
+        previous:
+          $ref: '#/components/schemas/PagePrevious'
+        results:
+          description: 'List of Namespaces for this Page'
+          type: array
+          items:
+            $ref: '#/components/schemas/Namespace'
+
+    RepositoryNameError:
+      allOf:
+        - $ref: '#/components/schemas/ConflictError'
+
+    ValidationError:
+      allOf:
+        - $ref: '#/components/schemas/APIException'
+
+    PageCount:
+      type: integer
+
+    PageNext:
+      type: string
+
+    PagePrevious:
+      type: string
+
     ProviderNamespace:
       description: 'A Provider Namespace'
       allOf:
@@ -1159,6 +1165,22 @@ components:
               type: string
           required:
             - name
+
+    ProviderNamespacesPage:
+      description: 'A page of a list of Provider Namespaces'
+      type: object
+      properties:
+        count:
+          $ref: '#/components/schemas/PageCount'
+        next:
+          $ref: '#/components/schemas/PageNext'
+        previous:
+          $ref: '#/components/schemas/PagePrevious'
+        results:
+          description: 'List of Provider Namespaces'
+          type: array
+          items:
+            $ref: '#/components/schemas/ProviderNamespace'
 
     Role:
       description: 'An Ansible Role'
@@ -1214,6 +1236,32 @@ components:
             - search_rank
             - download_rank
 
+    RolesPage:
+      description: "A Page of a list of Roles"
+      type: object
+      properties:
+        count:
+          $ref: '#/components/schemas/PageCount'
+        next:
+          $ref: '#/components/schemas/PageNext'
+        previous:
+          $ref: '#/components/schemas/PagePrevious'
+        results:
+          description: 'List of Roles for this Page'
+          type: array
+          items:
+            $ref: '#/components/schemas/Role'
+
+    SemanticVersion:
+      description: 'A version string in the Semantic Version form'
+      type: string
+      example: '1.0.1'
+
+    SemanticVersionSpec:
+      description: 'A string to match against SemanticVersion'
+      type: string
+      example: '>=1.0.0'
+
     Tag:
       description: 'A Galaxy Tag'
       allOf:
@@ -1225,6 +1273,22 @@ components:
               type: string
           required:
             - name
+
+    TagsPage:
+      description: "A page of a list of Galaxy Tags"
+      type: object
+      properties:
+        count:
+          $ref: '#/components/schemas/PageCount'
+        next:
+          $ref: '#/components/schemas/PageNext'
+        previous:
+          $ref: '#/components/schemas/PagePrevious'
+        results:
+          description: 'List of Tags for this Page'
+          type: array
+          items:
+            $ref: '#/components/schemas/Tag'
 
     User:
       description: 'A User'
@@ -1254,6 +1318,22 @@ components:
           required:
             - username
 
+    UsersPage:
+      description: "A page of a list of Users"
+      type: object
+      properties:
+        count:
+          $ref: '#/components/schemas/PageCount'
+        next:
+          $ref: '#/components/schemas/PageNext'
+        previous:
+          $ref: '#/components/schemas/PagePrevious'
+        results:
+          description: 'List of Users for this Page'
+          type: array
+          items:
+            $ref: '#/components/schemas/User'
+
     UserUpdate:
       description: 'User data to update'
       properties:
@@ -1274,126 +1354,45 @@ components:
           pattern: '^[a-zA-Z0-9_.@+-]+$'
           type: string
 
-    # Instead of creating a schema type for each paginated
-    # might be able to make 'results' a PageResults type.
-    # And make PageResults use 'anyOf' and a discriminator
-    # to 'choose' the correct type in the list. But currently
-    # there isn't info in the Page data that indicates the
-    # type to be expected in the 'results'. This would need
-    # something like a 'result_type': 'CollectionVersion' in
-    # the data.
-    CollectionVersionsPage:
-      description: 'A page of a list of CollectionVersionLinks'
+    V1BaseModel:
+      description: 'Base for common v1 shared model attributes'
       type: object
       properties:
-        count:
-          $ref: '#/components/schemas/PageCount'
-        next:
-          $ref: '#/components/schemas/PageNext'
-        previous:
-          $ref: '#/components/schemas/PagePrevious'
-        results:
-          description: 'List of CollectionVersionLinks for this Page'
-          type: array
-          items:
-            $ref: '#/components/schemas/CollectionVersionLink'
-
-    ContentsPage:
-      description: "A page of a list of Contents"
-      type: object
-      properties:
-        count:
-          $ref: '#/components/schemas/PageCount'
-        next:
-          $ref: '#/components/schemas/PageNext'
-        previous:
-          $ref: '#/components/schemas/PagePrevious'
-        results:
-          description: 'List of Contents for this Page'
-          type: array
-          items:
-            $ref: '#/components/schemas/Content'
-
-    NamespacesPage:
-      description: "A Page of a list of Namespaces"
-      type: object
-      properties:
-        count:
-          $ref: '#/components/schemas/PageCount'
-        next:
-          $ref: '#/components/schemas/PageNext'
-        previous:
-          $ref: '#/components/schemas/PagePrevious'
-        results:
-          description: 'List of Namespaces for this Page'
-          type: array
-          items:
-            $ref: '#/components/schemas/Namespace'
-
-    ProviderNamespacesPage:
-      description: 'A page of a list of Provider Namespaces'
-      type: object
-      properties:
-        count:
-          $ref: '#/components/schemas/PageCount'
-        next:
-          $ref: '#/components/schemas/PageNext'
-        previous:
-          $ref: '#/components/schemas/PagePrevious'
-        results:
-          description: 'List of Provider Namespaces'
-          type: array
-          items:
-            $ref: '#/components/schemas/ProviderNamespace'
-
-    RolesPage:
-      description: "A Page of a list of Roles"
-      type: object
-      properties:
-        count:
-          $ref: '#/components/schemas/PageCount'
-        next:
-          $ref: '#/components/schemas/PageNext'
-        previous:
-          $ref: '#/components/schemas/PagePrevious'
-        results:
-          description: 'List of Roles for this Page'
-          type: array
-          items:
-            $ref: '#/components/schemas/Role'
-
-    TagsPage:
-      description: "A page of a list of Galaxy Tags"
-      type: object
-      properties:
-        count:
-          $ref: '#/components/schemas/PageCount'
-        next:
-          $ref: '#/components/schemas/PageNext'
-        previous:
-          $ref: '#/components/schemas/PagePrevious'
-        results:
-          description: 'List of Tags for this Page'
-          type: array
-          items:
-            $ref: '#/components/schemas/Tag'
-
-    UsersPage:
-      description: "A page of a list of Users"
-      type: object
-      properties:
-        count:
-          $ref: '#/components/schemas/PageCount'
-        next:
-          $ref: '#/components/schemas/PageNext'
-        previous:
-          $ref: '#/components/schemas/PagePrevious'
-        results:
-          description: 'List of Users for this Page'
-          type: array
-          items:
-            $ref: '#/components/schemas/User'
-
+        id:
+          description: 'Database ID for this object.'
+          readOnly: true
+          type: integer
+        url:
+          description: 'URL for this resource.'
+          readOnly: true
+          type: string
+          format: uri
+        related:
+          description: 'Data structure with URLs of related resources.'
+          readOnly: true
+          type: object
+          additionalProperties:
+            type: string
+        summary_fields:
+          description: >-
+            Data structure with name/description for related
+            resources.
+          readOnly: true
+          type: object
+          additionalProperties: {}
+        active:
+          readOnly: true
+          type: string
+        modified:
+          description: 'Timestamp when this object was last modified.'
+          readOnly: true
+          type: string
+        created:
+          description: 'Timestamp when this object was created.'
+          readOnly: true
+          type: string
+      required:
+        - id
 
   responses:
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -38,12 +38,16 @@ tags:
     description: 'API endpoints from the v2 API'
   - name: 'me'
     description: 'API related to the current user.'
+  - name: 'pulp'
+    description: 'API related to Pulp'
   - name: 'search'
     description: 'API for searching'
   - name: 'namespaces'
     description: 'API for Namespaces'
   - name: 'tags'
     description: 'API for Ansible Galaxy tags.'
+  - name: 'tasks'
+    description: 'API for Pulp tasks'
   - name: 'users'
     description: 'API for Users'
   - name: 'v1'
@@ -273,7 +277,7 @@ paths:
     post:
       summary: 'Create a new CollectionVersionArtifact by uploading collection artifact'
       operationId: UploadCollectionVersionArtifact
-      description: 
+      description:
         Create a new CollectionVersionArtifact by uploading a collection artifact.
         This will add the new artifact, but will not create a new Collection.
         To create a CollectionVersionArtifact and a Collection, use 'POST /collections'
@@ -334,106 +338,6 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/CollectionVersionArtifact'
-  '/pulp/content/ansible/collections/':
-    description: 'Wrapper API for /pulp/api/v3/content/ansible/collections/'
-    get:
-      tags:
-        - collections
-        - pulp
-        - v3
-      summary: List collections
-      description: |
-        Wrapper for https://pulp-ansible.readthedocs.io/en/latest/restapi.html#operation/content_ansible_collections_list
-      operationId: GetPulpContentAnsibleCollections
-      parameters:
-      - name: name
-        in: query
-        description: Filter results where name matches value
-        schema:
-          type: string
-      - name: namespace
-        in: query
-        description: Filter results where namespace matches value
-        schema:
-          type: string
-      - name: version
-        in: query
-        description: Filter results where version matches value
-        schema:
-          type: string
-      - name: repository_version
-        in: query
-        description: Repository Version referenced by HREF
-        schema:
-          type: string
-      - name: repository_version_added
-        in: query
-        description: Repository Version referenced by HREF
-        schema:
-          type: string
-      - name: repository_version_removed
-        in: query
-        description: Repository Version referenced by HREF
-        schema:
-          type: string
-      - name: page
-        in: query
-        description: A page number within the paginated result set.
-        schema:
-          type: integer
-      - name: page_size
-        in: query
-        description: Number of results to return per page.
-        schema:
-          type: integer
-      responses:
-        200:
-          description: "response from getting pulp collection content"
-          content:
-            application/json:
-              schema:
-                required:
-                - count
-                - results
-                type: object
-                properties:
-                  next:
-                    type: string
-                    format: uri
-                    nullable: true
-                  previous:
-                    type: string
-                    format: uri
-                    nullable: true
-                  count:
-                    type: integer
-                  results:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/PulpCollection'
-    post:
-      summary: Create a collection
-      description: |
-        ViewSet for Ansible Collection.
-        Wrapper for https://pulp-ansible.readthedocs.io/en/latest/restapi.html#operation/content_ansible_collections_create
-      operationId: content_ansible_collections_create
-      tags:
-        - pulp
-        - collections
-        - v3
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/PulpCollection'
-        required: true
-      responses:
-        201:
-          description: ""
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PulpCollection'
 
   '/download/{filename}':
     get:
@@ -598,103 +502,106 @@ paths:
         - provider_namespaces
         - v3
 
-  '/search/':
+  '/pulp/content/ansible/collections/':
+    description: 'Wrapper API for /pulp/api/v3/content/ansible/collections/'
     get:
-      summary: 'Get info about the search API'
-      operationId: GetApiSearch
       tags:
-        - search
-        - introspection
-        - v1
-      parameters: []
+        - collections
+        - pulp
+        - v3
+      summary: List collections
+      description: |
+        Wrapper for https://pulp-ansible.readthedocs.io/en/latest/restapi.html#operation/content_ansible_collections_list
+      operationId: GetPulpContentAnsibleCollections
+      parameters:
+      - name: name
+        in: query
+        description: Filter results where name matches value
+        schema:
+          type: string
+      - name: namespace
+        in: query
+        description: Filter results where namespace matches value
+        schema:
+          type: string
+      - name: version
+        in: query
+        description: Filter results where version matches value
+        schema:
+          type: string
+      - name: repository_version
+        in: query
+        description: Repository Version referenced by HREF
+        schema:
+          type: string
+      - name: repository_version_added
+        in: query
+        description: Repository Version referenced by HREF
+        schema:
+          type: string
+      - name: repository_version_removed
+        in: query
+        description: Repository Version referenced by HREF
+        schema:
+          type: string
+      - name: page
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
       responses:
-        '200':
-          description: 'A map of endpoints in the search API'
+        200:
+          description: "response from getting pulp collection content"
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/APIEndpoints'
-
-  '/search/content/':
-    get:
-      summary: 'Get a list of Contents by searching'
-      operationId: ListContentBySearch
+                required:
+                - count
+                - results
+                type: object
+                properties:
+                  next:
+                    type: string
+                    format: uri
+                    nullable: true
+                  previous:
+                    type: string
+                    format: uri
+                    nullable: true
+                  count:
+                    type: integer
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PulpCollection'
+    post:
+      summary: Create a collection
+      description: |
+        ViewSet for Ansible Collection.
+        Wrapper for https://pulp-ansible.readthedocs.io/en/latest/restapi.html#operation/content_ansible_collections_create
+      operationId: content_ansible_collections_create
       tags:
-        - search
-        - v1
-      parameters:
-        - $ref: '#/components/parameters/Page'
-        - $ref: '#/components/parameters/PageSize'
+        - pulp
+        - collections
+        - v3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PulpCollection'
+        required: true
       responses:
-        '200':
-          $ref: '#/components/responses/Contents'
-
-  '/search/roles/':
-    get:
-      summary: 'Get a list of Roles by searching'
-      operationId: ListRoleBySearch
-      tags:
-        - search
-        - v1
-      parameters:
-        - $ref: '#/components/parameters/Page'
-        - $ref: '#/components/parameters/PageSize'
-      responses:
-        '200':
-          $ref: '#/components/responses/Roles'
-
-  '/search/tags/':
-    get:
-      summary: 'Get a list of Tags by searching'
-      operationId: ListTagBySearch
-      tags:
-        - search
-        - v1
-      parameters:
-        - $ref: '#/components/parameters/Page'
-        - $ref: '#/components/parameters/PageSize'
-        # TODO: search param tags
-      responses:
-        '200':
-          $ref: '#/components/responses/Tags'
-
-  '/tags/':
-    get:
-      summary: 'Get a list of Galaxy Tags'
-      operationId: ListTags
-      tags:
-        - tags
-        - v1
-      parameters:
-        - $ref: '#/components/parameters/Page'
-        - $ref: '#/components/parameters/PageSize'
-        - $ref: '#/components/parameters/Search'
-      responses:
-        '200':
-          $ref: '#/components/responses/Tags'
-
-  '/tags/{id}/':
-    get:
-      summary: 'Get a Galaxy Tag'
-      operationId: GetTagById
-      tags:
-        - tags
-        - v1
-      parameters:
-        - description: 'Tag id'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - $ref: '#/components/parameters/Search'
-      responses:
-        '200':
-          description: 'A Galaxy Tag'
+        201:
+          description: ""
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Tag'
+                $ref: '#/components/schemas/PulpCollection'
 
   # Could just make this /tasks/
   '/pulp/tasks/':
@@ -845,6 +752,7 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/PulpTask'
+
   '/pulp/tasks/{pulp_task_id}':
     description: 'Wrapper API for Pulp {task_href}'
     get:
@@ -915,6 +823,105 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/PulpTask'
+
+  '/search/':
+    get:
+      summary: 'Get info about the search API'
+      operationId: GetApiSearch
+      tags:
+        - search
+        - introspection
+        - v1
+      parameters: []
+      responses:
+        '200':
+          description: 'A map of endpoints in the search API'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIEndpoints'
+
+  '/search/content/':
+    get:
+      summary: 'Get a list of Contents by searching'
+      operationId: ListContentBySearch
+      tags:
+        - search
+        - v1
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+      responses:
+        '200':
+          $ref: '#/components/responses/Contents'
+
+  '/search/roles/':
+    get:
+      summary: 'Get a list of Roles by searching'
+      operationId: ListRoleBySearch
+      tags:
+        - search
+        - v1
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+      responses:
+        '200':
+          $ref: '#/components/responses/Roles'
+
+  '/search/tags/':
+    get:
+      summary: 'Get a list of Tags by searching'
+      operationId: ListTagBySearch
+      tags:
+        - search
+        - v1
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+        # TODO: search param tags
+      responses:
+        '200':
+          $ref: '#/components/responses/Tags'
+
+  '/tags/':
+    get:
+      summary: 'Get a list of Galaxy Tags'
+      operationId: ListTags
+      tags:
+        - tags
+        - v1
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          $ref: '#/components/responses/Tags'
+
+  '/tags/{id}/':
+    get:
+      summary: 'Get a Galaxy Tag'
+      operationId: GetTagById
+      tags:
+        - tags
+        - v1
+      parameters:
+        - description: 'Tag id'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          description: 'A Galaxy Tag'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Tag'
+
   '/users/':
     get:
       summary: 'Get a list of Users'
@@ -1640,6 +1647,148 @@ components:
           title: Namespace
           minLength: 1
           type: string
+
+    PulpProgressReport:
+      type: object
+      properties:
+        message:
+          title: Message
+          minLength: 1
+          type: string
+          description: The message shown to the user for the progress report.
+          readOnly: true
+        state:
+          title: State
+          minLength: 1
+          type: string
+          description: >-
+            The current state of the progress report. The possible values are:
+            'waiting', 'skipped', 'running', 'completed', 'failed' and
+            'canceled'. The default is 'waiting'.
+          readOnly: true
+        total:
+          title: Total
+          type: integer
+          description: The total count of items to be handled by the ProgressBar.
+          readOnly: true
+        done:
+          title: Done
+          type: integer
+          description: The count of items already processed. Defaults to 0.
+          readOnly: true
+        suffix:
+          title: Suffix
+          minLength: 1
+          type: string
+          description: The suffix to be shown with the progress report.
+          nullable: true
+          readOnly: true
+
+    PulpTask:
+      required:
+        - name
+      type: object
+      properties:
+        _href:
+          title: ' href'
+          type: string
+          format: uri
+          readOnly: true
+        _created:
+          title: ' created'
+          type: string
+          description: Timestamp of creation.
+          format: date-time
+          readOnly: true
+        state:
+          title: State
+          minLength: 1
+          type: string
+          description: >-
+            The current state of the task. The possible values include:
+            'waiting', 'skipped', 'running', 'completed', 'failed' and
+            'canceled'.
+          readOnly: true
+        name:
+          title: Name
+          minLength: 1
+          type: string
+          description: The name of task.
+        started_at:
+          title: Started at
+          type: string
+          description: Timestamp of the when this task started execution.
+          format: date-time
+          readOnly: true
+        finished_at:
+          title: Finished at
+          type: string
+          description: Timestamp of the when this task stopped execution.
+          format: date-time
+          readOnly: true
+        non_fatal_errors:
+          title: Non fatal errors
+          type: string
+          description: >-
+            A JSON Object of non-fatal errors encountered during the execution
+            of this task.
+          readOnly: true
+        error:
+          title: Error
+          type: string
+          description: >-
+            A JSON Object of a fatal error encountered during the execution of
+            this task.
+          readOnly: true
+        worker:
+          title: Worker
+          type: string
+          description: >-
+            The worker associated with this task. This field is empty if a
+            worker is not yet assigned.
+          format: uri
+          readOnly: true
+        parent:
+          title: Parent
+          type: string
+          description: The parent task that spawned this task.
+          format: uri
+          readOnly: true
+        spawned_tasks:
+          uniqueItems: true
+          type: array
+          description: Any tasks spawned by this task.
+          readOnly: true
+          items:
+            type: string
+            description: Any tasks spawned by this task.
+            format: uri
+        progress_reports:
+          type: array
+          readOnly: true
+          items:
+            $ref: '#/components/schemas/PulpProgressReport'
+        created_resources:
+          uniqueItems: true
+          type: array
+          description: Resources created by this task.
+          readOnly: true
+          items:
+            type: string
+            description: Resources created by this task.
+            format: uri
+
+    PulpTaskCancel:
+      required:
+        - state
+      type: object
+      properties:
+        state:
+          title: State
+          minLength: 1
+          type: string
+          description: The desired state of the task. Only 'canceled' is accepted.
+
     Role:
       description: 'An Ansible Role'
       title: 'Role'
@@ -1745,144 +1894,7 @@ components:
                 $ref: '#/components/schemas/Tag'
           required:
             - results
-    PulpProgressReport:
-      type: object
-      properties:
-        message:
-          title: Message
-          minLength: 1
-          type: string
-          description: The message shown to the user for the progress report.
-          readOnly: true
-        state:
-          title: State
-          minLength: 1
-          type: string
-          description: >-
-            The current state of the progress report. The possible values are:
-            'waiting', 'skipped', 'running', 'completed', 'failed' and
-            'canceled'. The default is 'waiting'.
-          readOnly: true
-        total:
-          title: Total
-          type: integer
-          description: The total count of items to be handled by the ProgressBar.
-          readOnly: true
-        done:
-          title: Done
-          type: integer
-          description: The count of items already processed. Defaults to 0.
-          readOnly: true
-        suffix:
-          title: Suffix
-          minLength: 1
-          type: string
-          description: The suffix to be shown with the progress report.
-          nullable: true
-          readOnly: true
-    PulpTask:
-      required:
-        - name
-      type: object
-      properties:
-        _href:
-          title: ' href'
-          type: string
-          format: uri
-          readOnly: true
-        _created:
-          title: ' created'
-          type: string
-          description: Timestamp of creation.
-          format: date-time
-          readOnly: true
-        state:
-          title: State
-          minLength: 1
-          type: string
-          description: >-
-            The current state of the task. The possible values include:
-            'waiting', 'skipped', 'running', 'completed', 'failed' and
-            'canceled'.
-          readOnly: true
-        name:
-          title: Name
-          minLength: 1
-          type: string
-          description: The name of task.
-        started_at:
-          title: Started at
-          type: string
-          description: Timestamp of the when this task started execution.
-          format: date-time
-          readOnly: true
-        finished_at:
-          title: Finished at
-          type: string
-          description: Timestamp of the when this task stopped execution.
-          format: date-time
-          readOnly: true
-        non_fatal_errors:
-          title: Non fatal errors
-          type: string
-          description: >-
-            A JSON Object of non-fatal errors encountered during the execution
-            of this task.
-          readOnly: true
-        error:
-          title: Error
-          type: string
-          description: >-
-            A JSON Object of a fatal error encountered during the execution of
-            this task.
-          readOnly: true
-        worker:
-          title: Worker
-          type: string
-          description: >-
-            The worker associated with this task. This field is empty if a
-            worker is not yet assigned.
-          format: uri
-          readOnly: true
-        parent:
-          title: Parent
-          type: string
-          description: The parent task that spawned this task.
-          format: uri
-          readOnly: true
-        spawned_tasks:
-          uniqueItems: true
-          type: array
-          description: Any tasks spawned by this task.
-          readOnly: true
-          items:
-            type: string
-            description: Any tasks spawned by this task.
-            format: uri
-        progress_reports:
-          type: array
-          readOnly: true
-          items:
-            $ref: '#/components/schemas/PulpProgressReport'
-        created_resources:
-          uniqueItems: true
-          type: array
-          description: Resources created by this task.
-          readOnly: true
-          items:
-            type: string
-            description: Resources created by this task.
-            format: uri
-    PulpTaskCancel:
-      required:
-        - state
-      type: object
-      properties:
-        state:
-          title: State
-          minLength: 1
-          type: string
-          description: The desired state of the task. Only 'canceled' is accepted.
+
     User:
       description: 'A User'
       title: 'User'

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -174,7 +174,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/CollectionNamespace'
       - $ref: '#/components/parameters/CollectionName'
-      - $ref: '#/components/parameters/CollectionVersion'
+      - $ref: '#/components/parameters/SemanticVersion'
     get:
       summary: 'Get a CollectionVersion by namespace, name, and version'
       operationId: GetCollectionVersion
@@ -190,7 +190,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/CollectionNamespace'
       - $ref: '#/components/parameters/CollectionName'
-      - $ref: '#/components/parameters/CollectionVersion'
+      - $ref: '#/components/parameters/SemanticVersion'
     get:
       summary: 'Get Artifact details for a Collection by namespace, name, and version'
       operationId: GetCollectionVersionArtifact
@@ -530,7 +530,6 @@ paths:
         - v3
 
   '/pulp/content/ansible/collections/':
-    description: 'Wrapper API for /pulp/api/v3/content/ansible/collections/'
     get:
       tags:
         - collections
@@ -609,7 +608,6 @@ paths:
 
   # Could just make this /tasks/
   '/pulp/tasks/':
-    description: 'Wrapper API for Pulp tasks API'
     get:
       tags:
         - tasks
@@ -729,7 +727,6 @@ paths:
           $ref: '#/components/responses/PulpTasks'
 
   '/pulp/tasks/{pulp_task_id}':
-    description: 'Wrapper API for Pulp {task_href}'
     get:
       tags:
         - tasks
@@ -2262,15 +2259,6 @@ components:
         type: string
         pattern: ^(?!.*__)[a-z]+[0-9a-z_]*$'
 
-    CollectionVersion:
-      description: 'A Semantic Version string'
-      in: path
-      name: version
-      required: true
-      schema:
-        type: string
-        pattern: ^((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$
-
     CollectionVersionArtifactFilename:
       description: 'CollectionVersion artifact filename'
       in: path
@@ -2330,6 +2318,15 @@ components:
       required: false
       schema:
         type: string
+
+    SemanticVersion:
+      description: 'A Semantic Version string'
+      in: path
+      name: version
+      required: true
+      schema:
+        type: string
+        pattern: ^((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$
 
     TagId:
       description: 'Tag id'

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -124,7 +124,7 @@ paths:
         - $ref: '#/components/parameters/Search'
       responses:
         '200':
-          $ref: '#/components/responses/CollectionVersions'
+          $ref: '#/components/responses/CollectionVersionLinks'
 
   '/collections/{namespace}/{name}/':
     parameters:
@@ -162,7 +162,7 @@ paths:
         - $ref: '#/components/parameters/Search'
       responses:
         '200':
-          $ref: '#/components/responses/CollectionVersions'
+          $ref: '#/components/responses/CollectionVersionLinks'
 
   '/collections/{namespace}/{name}/versions/{version}/':
     parameters:
@@ -763,12 +763,13 @@ components:
       pattern: '^(?!.*__)[a-z]+[0-9a-z_]*$'
 
     CollectionNamespaceName:
-      description: 'The Collection namespace'
+      description: 'The name of the Collection Namespace'
       type: string
       example: 'my_namespace'
       pattern: '^(?!.*__)[a-z]+[0-9a-z_]*$'
 
     CollectionNamespace:
+      description: 'The Collection Namespace'
       type: object
       properties:
         name:
@@ -781,6 +782,8 @@ components:
           format: uri
 
     CollectionVersion:
+      description: 'Collection Version'
+      title: 'Collection Version'
       type: object
       properties:
         artifact:
@@ -925,6 +928,7 @@ components:
 
     CollectionVersionLink:
       type: object
+      title: 'CollectionVersionLink'
       properties:
         href:
           description: 'The URL to the CollectionVersion'
@@ -933,31 +937,23 @@ components:
           type: string
           maxLength: 64
 
-    # Instead of creating a schema type for each paginated
-    # might be able to make 'results' a PageResults type.
-    # And make PageResults use 'anyOf' and a discriminator
-    # to 'choose' the correct type in the list. But currently
-    # there isn't info in the Page data that indicates the
-    # type to be expected in the 'results'. This would need
-    # something like a 'result_type': 'CollectionVersion' in
-    # the data.
-    CollectionVersionsPage:
+    CollectionVersionLinksPage:
       description: 'A page of a list of CollectionVersionLinks'
-      type: object
-      properties:
-        count:
-          $ref: '#/components/schemas/PageCount'
-        next:
-          $ref: '#/components/schemas/PageNext'
-        previous:
-          $ref: '#/components/schemas/PagePrevious'
-        results:
-          description: 'List of CollectionVersionLinks for this Page'
-          type: array
-          items:
-            $ref: '#/components/schemas/CollectionVersionLink'
+      allOf:
+        - $ref: '#/components/schemas/PageInfo'
+        - type: object
+          properties:
+            results:
+              description: 'List of CollectionVersionLinks for this Page'
+              title: 'CollectionVersionLinks'
+              type: array
+              items:
+                $ref: '#/components/schemas/CollectionVersionLink'
+          required:
+            - results
 
     ConflictError:
+      title: 'ConflictError'
       allOf:
         - $ref: '#/components/schemas/APIException'
 
@@ -966,6 +962,7 @@ components:
         - $ref: '#/components/schemas/ConflictError'
 
     Content:
+      title: 'Content'
       allOf:
         - $ref: '#/components/schemas/V1BaseModel'
         - type: object
@@ -1020,19 +1017,18 @@ components:
 
     ContentsPage:
       description: "A page of a list of Contents"
-      type: object
-      properties:
-        count:
-          $ref: '#/components/schemas/PageCount'
-        next:
-          $ref: '#/components/schemas/PageNext'
-        previous:
-          $ref: '#/components/schemas/PagePrevious'
-        results:
-          description: 'List of Contents for this Page'
-          type: array
-          items:
-            $ref: '#/components/schemas/Content'
+      allOf:
+        - $ref: '#/components/schemas/PageInfo'
+        - type: object
+          properties:
+            results:
+              description: 'List of Contents for this Page'
+              title: 'Contents'
+              type: array
+              items:
+                $ref: '#/components/schemas/Content'
+          required:
+            - results
 
     Error:
       type: object
@@ -1060,6 +1056,7 @@ components:
       example: 'development'
 
     Namespace:
+      title: 'Namespace'
       description: 'A Namespace'
       allOf:
         - $ref: '#/components/schemas/V1BaseModel'
@@ -1098,19 +1095,18 @@ components:
 
     NamespacesPage:
       description: "A Page of a list of Namespaces"
-      type: object
-      properties:
-        count:
-          $ref: '#/components/schemas/PageCount'
-        next:
-          $ref: '#/components/schemas/PageNext'
-        previous:
-          $ref: '#/components/schemas/PagePrevious'
-        results:
-          description: 'List of Namespaces for this Page'
-          type: array
-          items:
-            $ref: '#/components/schemas/Namespace'
+      allOf:
+        - $ref: '#/components/schemas/PageInfo'
+        - type: object
+          properties:
+            results:
+              description: 'List of Namespaces for this Page'
+              title: 'Namespaces'
+              type: array
+              items:
+                $ref: '#/components/schemas/Namespace'
+          required:
+            - results
 
     RepositoryNameError:
       allOf:
@@ -1123,14 +1119,31 @@ components:
     PageCount:
       type: integer
 
+    PageInfo:
+      description: 'Pagination info'
+      title: 'Page Info'
+      properties:
+        count:
+          $ref: '#/components/schemas/PageCount'
+        next:
+          $ref: '#/components/schemas/PageNext'
+        previous:
+          $ref: '#/components/schemas/PagePrevious'
+        result_type:
+          type: string
+          description: 'The type of object in the results list'
+          nullable: true
+
     PageNext:
       type: string
 
     PagePrevious:
+      description: 'The previous page'
       type: string
 
     ProviderNamespace:
       description: 'A Provider Namespace'
+      title: 'ProviderNamespace'
       allOf:
         - $ref: '#/components/schemas/V1BaseModel'
         - type: object
@@ -1168,22 +1181,22 @@ components:
 
     ProviderNamespacesPage:
       description: 'A page of a list of Provider Namespaces'
-      type: object
-      properties:
-        count:
-          $ref: '#/components/schemas/PageCount'
-        next:
-          $ref: '#/components/schemas/PageNext'
-        previous:
-          $ref: '#/components/schemas/PagePrevious'
-        results:
-          description: 'List of Provider Namespaces'
-          type: array
-          items:
-            $ref: '#/components/schemas/ProviderNamespace'
+      title: 'Provider Namespaces Page'
+      allOf:
+        - $ref: '#/components/schemas/PageInfo'
+        - type: object
+          properties:
+            results:
+              title: 'ProviderNamespaces'
+              type: array
+              items:
+                $ref: '#/components/schemas/ProviderNamespace'
+          required:
+            - results
 
     Role:
       description: 'An Ansible Role'
+      title: 'Role'
       allOf:
         - $ref: '#/components/schemas/V1BaseModel'
         - type: object
@@ -1238,19 +1251,16 @@ components:
 
     RolesPage:
       description: "A Page of a list of Roles"
-      type: object
-      properties:
-        count:
-          $ref: '#/components/schemas/PageCount'
-        next:
-          $ref: '#/components/schemas/PageNext'
-        previous:
-          $ref: '#/components/schemas/PagePrevious'
-        results:
-          description: 'List of Roles for this Page'
-          type: array
-          items:
-            $ref: '#/components/schemas/Role'
+      allOf:
+        - $ref: '#/components/schemas/PageInfo'
+        - type: object
+          properties:
+            results:
+              description: 'List of Roles for this Page'
+              title: 'Roles'
+              type: array
+              items:
+                $ref: '#/components/schemas/Role'
 
     SemanticVersion:
       description: 'A version string in the Semantic Version form'
@@ -1263,6 +1273,7 @@ components:
       example: '>=1.0.0'
 
     Tag:
+      title: 'Tag'
       description: 'A Galaxy Tag'
       allOf:
         - $ref: '#/components/schemas/V1BaseModel'
@@ -1276,22 +1287,22 @@ components:
 
     TagsPage:
       description: "A page of a list of Galaxy Tags"
-      type: object
-      properties:
-        count:
-          $ref: '#/components/schemas/PageCount'
-        next:
-          $ref: '#/components/schemas/PageNext'
-        previous:
-          $ref: '#/components/schemas/PagePrevious'
-        results:
-          description: 'List of Tags for this Page'
-          type: array
-          items:
-            $ref: '#/components/schemas/Tag'
+      allOf:
+        - $ref: '#/components/schemas/PageInfo'
+        - type: object
+          properties:
+            results:
+              description: 'List of Tags for this Page'
+              title: 'Tags'
+              type: array
+              items:
+                $ref: '#/components/schemas/Tag'
+          required:
+            - results
 
     User:
       description: 'A User'
+      title: 'User'
       allOf:
         - $ref: '#/components/schemas/V1BaseModel'
         - type: object
@@ -1320,19 +1331,18 @@ components:
 
     UsersPage:
       description: "A page of a list of Users"
-      type: object
-      properties:
-        count:
-          $ref: '#/components/schemas/PageCount'
-        next:
-          $ref: '#/components/schemas/PageNext'
-        previous:
-          $ref: '#/components/schemas/PagePrevious'
-        results:
-          description: 'List of Users for this Page'
-          type: array
-          items:
-            $ref: '#/components/schemas/User'
+      allOf:
+        - $ref: '#/components/schemas/PageInfo'
+        - type: object
+          properties:
+            results:
+              description: 'List of Users for this Page'
+              title: 'Users'
+              type: array
+              items:
+                $ref: '#/components/schemas/User'
+          required:
+            - results
 
     UserUpdate:
       description: 'User data to update'
@@ -1403,12 +1413,12 @@ components:
           schema:
             $ref: '#/components/schemas/CollectionCreationResult'
 
-    CollectionVersions:
+    CollectionVersionLinks:
       description: 'Response containing a page of CollectionVersionLinks'
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/CollectionVersionsPage'
+            $ref: '#/components/schemas/CollectionVersionLinksPage'
 
     CollectionVersion:
       description: 'Response contain a CollectionVersion'

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -307,7 +307,9 @@ paths:
   '/collection-version-artifacts/{artifact_id}':
     get:
       summary: 'Get a Collection Version artifacts'
-      operationId: GetCollectionVersionArtifact
+      operationId: GetCollectionVersionArtifactByArtifactId
+      parameters:
+        - $ref: '#/components/parameters/CollectionVersionArtifactId'
       tags:
         - collection-version-artifacts
         - v3
@@ -319,6 +321,8 @@ paths:
     get:
       summary: 'Download a Collection Version artifact'
       operationId: DownloadCollectionVersionArtifact
+      parameters:
+        - $ref: '#/components/parameters/CollectionVersionArtifactId'
       tags:
         - collection-version-artifacts
         - v3
@@ -785,9 +789,9 @@ paths:
       summary: Delete a task
       operationId: DeletePulpTask
       parameters:
-        - name: task_href
+        - name: pulp_task_id
           in: path
-          description: 'URI of Task. e.g.: /pulp/api/v3/tasks/1/'
+          description: 'ID of Task. e.g.: /pulp/api/v3/tasks/1/'
           required: true
           schema:
             type: string
@@ -804,9 +808,9 @@ paths:
       description: This operation cancels a task.
       operationId: PatchPulpTask
       parameters:
-        - name: task_href
+        - name: pulp_task_id
           in: path
-          description: 'URI of Task. e.g.: /pulp/api/v3/tasks/1/'
+          description: 'ID of Task. e.g.: /pulp/api/v3/tasks/1/'
           required: true
           schema:
             type: string
@@ -2196,6 +2200,14 @@ components:
       description: 'CollectionVersion artifact filename'
       in: path
       name: filename
+      required: true
+      schema:
+        type: string
+
+    CollectionVersionArtifactId:
+      description: 'CollectionVersion artifact ID'
+      in: path
+      name: artifact_id
       required: true
       schema:
         type: string

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,24 +1,20 @@
 info:
-  description: 'Galaxy 3.2 API (wip)'
-  title: 'Galaxy 3.2 API (wip)'
+  description: 'Galaxy autohub API (wip)'
+  title: 'Galaxy autohub API (wip)'
   version: "1.2.0"
   contact:
     url: https://github.com/ansible/galaxy/issues
     name: 'Ansible Galaxy Issues'
-    
+
 openapi: 3.0.0
 
 servers:
-  - url: https://galaxy.ansible.com/
-    description: 'Production server (uses live data)'
-  - url: https://galaxy-dev.ansible.com/
-    description: 'shared public dev server'
-  - url: http://localhost:5001
+  - url: http://localhost:5001/api/v3/
     description: 'local dev server'
-    
+
 externalDocs:
   url: https://galaxy.ansible.com/docs/
-  
+
 tags:
   - name: 'collections'
     externalDocs:
@@ -43,9 +39,9 @@ tags:
   - name: 'users'
   - name: 'v1'
     description: 'API endpoints from the v1 API.'
-    
+
 paths:
-  '/api/':
+  '/':
     get:
       summary: 'Get info about the API'
       operationId: GetAPI
@@ -59,27 +55,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/APIEndpoints'
- 
-  '/api/v1/':
+
+  '/search/':
     get:
-      summary: 'Get info about the v1 API'
-      operationId: GetApiV1
-      tags:
-        - introspection
-        - v1
-      parameters: []
-      responses:
-        '200':
-          description: 'A map of endpoints in the v1 API'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/APIEndpoints'
-                
-  '/api/v1/search/':
-    get:
-      summary: 'Get info about the v1 search API'
-      operationId: GetApiV1Search
+      summary: 'Get info about the search API'
+      operationId: GetApiSearch
       tags:
         - search
         - introspection
@@ -87,13 +67,13 @@ paths:
       parameters: []
       responses:
         '200':
-          description: 'A map of endpoints in the v1 search API'
+          description: 'A map of endpoints in the search API'
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/APIEndpoints'
-                  
-  '/api/v1/me/':
+
+  '/me/':
     get:
       summary: 'Get the User info for the current user'
       operationId: GetMeDetail
@@ -114,7 +94,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/User'
 
-  '/api/v1/namespaces/':
+  '/namespaces/':
     get:
       summary: 'Get a list of Namespaces'
       operationId: ListNamespaces
@@ -128,8 +108,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Namespaces'
-          
-  '/api/v1/search/content/':
+
+  '/search/content/':
     get:
       summary: 'Get a list of Contents by searching'
       operationId: ListContentBySearch
@@ -143,7 +123,7 @@ paths:
         '200':
           $ref: '#/components/responses/Contents'
 
-  '/api/v1/search/roles/':
+  '/search/roles/':
     get:
       operationId: ListRoleBySearch
       tags:
@@ -155,8 +135,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Roles'
-          
-  '/api/v1/search/tags/':
+
+  '/search/tags/':
     get:
       summary: 'Get a list of Tags by searching'
       operationId: ListTagBySearch
@@ -170,8 +150,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Tags'
-          
-  '/api/v1/tags/':
+
+  '/tags/':
     get:
       summary: 'Get a list of Galaxy Tags'
       operationId: ListTags
@@ -185,8 +165,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Tags'
-          
-  '/api/v1/tags/{id}/':
+
+  '/tags/{id}/':
     get:
       summary: 'Get a Galaxy Tag'
       operationId: GetTagById
@@ -208,8 +188,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Tag'
-  
-  '/api/v1/users/':
+
+  '/users/':
     get:
       summary: 'Get a list of Users'
       operationId: ListUsers
@@ -224,7 +204,7 @@ paths:
         '200':
           $ref: '#/components/responses/Users'
 
-  '/api/v1/users/{id}/':
+  '/users/{id}/':
     get:
       summary: 'Get an User by id'
       operationId: GetUserById
@@ -266,7 +246,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/User'
 
-  '/api/v2/collection-imports/{id}/':
+  '/collection-imports/{id}/':
     get:
       summary: 'Get a Collection-Import (import task) by id'
       operationId: GetCollectionImportById
@@ -288,8 +268,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CollectionImportResult'
-                
-  '/api/v2/collection-versions/{id}/artifact/':
+
+  '/collection-versions/{id}/artifact/':
     get:
       operationId: GetCollectionVersionArtifactById
       tags:
@@ -307,7 +287,7 @@ paths:
         '200':
           $ref: '#/components/responses/CollectionVersionArtifact'
 
-  '/api/v2/collection-versions/{version_pk}/':
+  '/collection-versions/{version_pk}/':
     get:
       summary: 'Get a CollectionVersion by version_pk'
       operationId: GetCollectionVersionByVersionPk
@@ -324,8 +304,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/CollectionVersion'
-                
-  '/api/v2/collections/':
+
+  '/collections/':
     post:
       summary: 'Create a new CollectionVersion by importing a collection artifact'
       operationId: ImportCollectionVersionArtifact
@@ -353,8 +333,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          
-  '/api/v2/collections/{id}/':
+
+  '/collections/{id}/':
     get:
       summary: 'Get a Collection by id'
       operationId: GetCollectionById
@@ -371,7 +351,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Collection'
 
-  '/api/v2/collections/{id}/versions/':
+  '/collections/{id}/versions/':
     get:
       summary: 'Get list of versions for a collection id'
       operationId: ListCollectionVersionsById
@@ -386,8 +366,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/CollectionVersions'
-          
-  '/api/v2/collections/{namespace}/{name}/':
+
+  '/collections/{namespace}/{name}/':
     parameters:
       - $ref: '#/components/parameters/CollectionNamespace'
       - $ref: '#/components/parameters/CollectionName'
@@ -405,8 +385,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Collection'
-                
-  '/api/v2/collections/{namespace}/{name}/versions/':
+
+  '/collections/{namespace}/{name}/versions/':
     parameters:
       - $ref: '#/components/parameters/CollectionNamespace'
       - $ref: '#/components/parameters/CollectionName'
@@ -424,8 +404,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/CollectionVersions'
-          
-  '/api/v2/collections/{namespace}/{name}/versions/{version}/':
+
+  '/collections/{namespace}/{name}/versions/{version}/':
     parameters:
       - $ref: '#/components/parameters/CollectionNamespace'
       - $ref: '#/components/parameters/CollectionName'
@@ -440,8 +420,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/CollectionVersion'
-                
-  '/api/v2/collections/{namespace}/{name}/versions/{version}/artifact/':
+
+  '/collections/{namespace}/{name}/versions/{version}/artifact/':
     parameters:
       - $ref: '#/components/parameters/CollectionNamespace'
       - $ref: '#/components/parameters/CollectionName'
@@ -502,7 +482,7 @@ components:
       required:
         - code
         - message
-        
+
     APIException:
       type: object
       description: 'API Exception'
@@ -522,42 +502,42 @@ components:
       required:
         - code
         - message
-        
+
     ConflictError:
       allOf:
         - $ref: '#/components/schemas/APIException'
-        
+
     ConflictCollectionExistsError:
       allOf:
         - $ref: '#/components/schemas/ConflictError'
-        
+
     RepositoryNameError:
       allOf:
         - $ref: '#/components/schemas/ConflictError'
-        
+
     ArtifactExistsError:
       allOf:
         - $ref: '#/components/schemas/ConflictError'
-        
+
     ValidationError:
       allOf:
         - $ref: '#/components/schemas/APIException'
-        
+
     APIEndpoints:
       description: 'Map of API endpoint names to URLS'
       type: object
       additionalProperties:
         type: string
-        
+
     PageCount:
       type: integer
-      
+
     PageNext:
       type: string
-      
+
     PagePrevious:
       type: string
-      
+
     CollectionVersionLink:
       type: object
       properties:
@@ -581,19 +561,19 @@ components:
           type: string
         size:
           type: integer
-          
+
     CollectionName:
       description: 'The name of a Collection'
       type: string
       example: 'my_collection'
       pattern: '^(?!.*__)[a-z]+[0-9a-z_]*$'
-      
+
     CollectionNamespaceName:
       description: 'The Collection namespace'
       type: string
       example: 'my_namespace'
       pattern: '^(?!.*__)[a-z]+[0-9a-z_]*$'
-      
+
     Collection:
       description: 'An Ansible Collection'
       type: object
@@ -620,7 +600,7 @@ components:
           format: uri
         versions_url:
           type: string
-          
+
     CollectionImportError:
       type: object
       properties:
@@ -630,7 +610,7 @@ components:
           type: string
         traceback:
           type: string
-          
+
     CollectionImportMessage:
       description: 'Message from collection importer including lint results'
 
@@ -647,7 +627,7 @@ components:
         - level
         - message
         - time
-          
+
     CollectionImportLintRecord:
       description: 'Records from collection linters'
       type: object
@@ -672,7 +652,7 @@ components:
           description: 'The url for the queued collection import task. Check it for progress and status.'
           type: string
           format: uri
-          
+
     CollectionImportResult:
       description: 'Collection import result'
       type: object
@@ -723,7 +703,7 @@ components:
         - started_at
         - state
         - version
-          
+
     CollectionNamespace:
       type: object
       properties:
@@ -735,7 +715,7 @@ components:
           description: 'link to the Namespace'
           type: string
           format: uri
-          
+
     CollectionVersionDetailCollection:
       type: object
       properties:
@@ -747,7 +727,7 @@ components:
           description: 'link to the Collection'
           type: string
           format: uri
-          
+
     CollectionVersionDetailArtifact:
       type: object
       properties:
@@ -757,41 +737,41 @@ components:
           type: integer
         sha256:
           type: string
-          
+
     SemanticVersion:
       description: 'A version string in the Semantic Version form'
       type: string
       example: '1.0.1'
-      
+
     SemanticVersionSpec:
       description: 'A string to match against SemanticVersion'
       type: string
       example: '>=1.0.0'
-      
+
     CollectionVersionDependencies:
       description: 'A map of collection namespace.name to a semantic version'
       type: object
       additionalProperties:
         $ref: '#/components/schemas/SemanticVersionSpec'
-      
+
     CollectionVersionLicense:
       description: 'A SPDX license id'
       type: string
       # TODO: This could in theory be an enum
-        
+
     GalaxyTag:
       description: 'A Galaxy Tag'
       type: string
       pattern: '^[a-z0-9]+$'
       example: 'development'
-        
+
     Author:
       description: 'Author of a collection or role'
       type: string
       format: email
       # TODO: add author validation pattern
       example: 'Adrian Likins <alikins@redhat.com>'
-      
+
     CollectionVersionDetailMetadata:
       description: "The Collection Version metadata from collections galaxy.yml or MANIFEST.JSON"
       type: object
@@ -853,12 +833,12 @@ components:
         - namespace
         - name
         - version
-        
+
     CollectionVersion:
       type: object
       properties:
         artifact:
-          $ref: '#/components/schemas/CollectionVersionDetailArtifact'   
+          $ref: '#/components/schemas/CollectionVersionDetailArtifact'
         metadata:
           $ref: '#/components/schemas/CollectionVersionDetailMetadata'
         hidden:
@@ -878,7 +858,7 @@ components:
 
     CollectionVersionArtifactData:
       description: 'CollectionVersionArtifact archive file binary and sha256 checksum. Used for importing collection artifacts'
-      type: object 
+      type: object
       properties:
         sha256:
           description: 'The sha256sum of the collection artifact file'
@@ -887,9 +867,9 @@ components:
           description: 'The binary contents of a collection artifact'
           type: string
           format: binary
-                
+
     V1BaseModel:
-      description: 'Base for common v1 shared model attributes' 
+      description: 'Base for common v1 shared model attributes'
       type: object
       properties:
         id:
@@ -927,8 +907,8 @@ components:
           type: string
       required:
         - id
-        
-      
+
+
     Content:
       allOf:
         - $ref: '#/components/schemas/V1BaseModel'
@@ -981,11 +961,11 @@ components:
             - relevance
             - search_rank
             - download_rank
-          
+
     Namespace:
       description: 'A Namespace'
       allOf:
-        - $ref: '#/components/schemas/V1BaseModel'      
+        - $ref: '#/components/schemas/V1BaseModel'
         - type: object
           properties:
             avatar_url:
@@ -1018,11 +998,11 @@ components:
               type: string
           required:
             - name
-        
+
     Role:
       description: 'An Ansible Role'
       allOf:
-        - $ref: '#/components/schemas/V1BaseModel'  
+        - $ref: '#/components/schemas/V1BaseModel'
         - type: object
           properties:
             company:
@@ -1074,9 +1054,9 @@ components:
             - download_rank
 
     Tag:
-      description: 'A v1 galaxy Tag'
+      description: 'A Galaxy Tag'
       allOf:
-        - $ref: '#/components/schemas/V1BaseModel'  
+        - $ref: '#/components/schemas/V1BaseModel'
         - type: object
           properties:
             name:
@@ -1084,11 +1064,11 @@ components:
               type: string
           required:
             - name
-        
+
     User:
-      description: 'A v1 User'
+      description: 'A User'
       allOf:
-        - $ref: '#/components/schemas/V1BaseModel' 
+        - $ref: '#/components/schemas/V1BaseModel'
         - type: object
           properties:
             avatar_url:
@@ -1112,7 +1092,7 @@ components:
               type: string
           required:
             - username
-        
+
     UserUpdate:
       description: 'User data to update'
       properties:
@@ -1156,7 +1136,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CollectionVersionLink'
-            
+
     ContentsPage:
       description: "A page of a list of Contents"
       type: object
@@ -1172,7 +1152,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Content'
-            
+
     NamespacesPage:
       description: "A Page of a list of Namespaces"
       type: object
@@ -1187,8 +1167,8 @@ components:
           description: 'List of Namespaces for this Page'
           type: array
           items:
-            $ref: '#/components/schemas/Namespace' 
-            
+            $ref: '#/components/schemas/Namespace'
+
     RolesPage:
       description: "A Page of a list of Roles"
       type: object
@@ -1203,8 +1183,8 @@ components:
           description: 'List of Roles for this Page'
           type: array
           items:
-            $ref: '#/components/schemas/Role' 
-            
+            $ref: '#/components/schemas/Role'
+
     TagsPage:
       description: "A page of a list of Galaxy Tags"
       type: object
@@ -1220,7 +1200,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Tag'
-            
+
     UsersPage:
       description: "A page of a list of Users"
       type: object
@@ -1253,7 +1233,7 @@ components:
                 conflict.collection_exists: '#/components/schemas/ConflictCollectionExistsError'
                 conflict.repository_name_conflict: '#/compontents/schemas/RepositoryNameError'
                 conflict.artifact_exists: '#/compontents/schemas/ArtifactExistsError'
-                
+
     Unauthorized:
       description: 'Authorization error'
       headers:
@@ -1292,7 +1272,7 @@ components:
             id: '$response.body#/id'
           description: >
             The `id` value returned in the response can be used as
-            the `id` parameter in `{method} GET /api/v2/collection-versions/{id}`.
+            the `id` parameter in `{method} GET /collection-versions/{id}`.
         GetCollectionById:
           operationId: GetCollectionById
           parameters:
@@ -1318,35 +1298,35 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CollectionCreationResult'
-            
+
     Contents:
       description: 'Response containing a Page of Content search results'
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ContentsPage'
-            
+
     Users:
       description: 'Response containing a Page of a list of Users'
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/UsersPage'
-            
+
     Namespaces:
       description: 'Response containing a Page of a list of Namespaces'
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/NamespacesPage'
-            
+
     Roles:
       description: 'Response containing a Page of a list of Roles'
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/RolesPage'
-     
+
     Tags:
       description: 'Response containing a Page of a list of Tags'
       content:
@@ -1363,7 +1343,7 @@ components:
       schema:
         type: integer
         default: 1
-        
+
     PageSize:
       description: 'Number of results to return per page.'
       in: query
@@ -1374,7 +1354,7 @@ components:
         default: 10
         minimum: 0
         maximum: 1000
-        
+
     Search:
       description: 'Term to search for'
       in: query
@@ -1382,7 +1362,7 @@ components:
       required: false
       schema:
         type: string
-        
+
     CollectionId:
       description: 'The Collection id'
       in: path
@@ -1390,7 +1370,7 @@ components:
       required: true
       schema:
         type: string
-        
+
     CollectionNamespace:
       description: 'The collection namespace'
       in: path
@@ -1398,7 +1378,7 @@ components:
       required: true
       schema:
         type: string
-        
+
     CollectionName:
       description: 'The collection name'
       in: path
@@ -1407,7 +1387,7 @@ components:
       schema:
         type: string
         pattern: ^(?!.*__)[a-z]+[0-9a-z_]*$'
-        
+
     CollectionVersion:
       description: 'A Semantic Version string'
       in: path
@@ -1416,7 +1396,7 @@ components:
       schema:
         type: string
         pattern: ^((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$
-        
+
     UserId:
       description: 'User id'
       in: path
@@ -1424,7 +1404,7 @@ components:
       required: true
       schema:
         type: string
-        
+
   requestBodies:
     CollectionVersionArtifactBody:
       description: "A multipart/form encoded payload including the binary collection artifact file contents and it's sha256sum"

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -81,7 +81,7 @@ paths:
         $ref: '#/components/requestBodies/CollectionVersionArtifactBody'
       responses:
         '202':
-          $ref: '#/components/responses/CreateCollectionResult'
+          $ref: '#/components/responses/CollectionImportAccepted'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '409':
@@ -1472,8 +1472,8 @@ components:
           schema:
             $ref: '#/components/schemas/CollectionVersionArtifactDetail'
 
-    CreateCollectionResult:
-      description: 'Result of collection import task with task url'
+    CollectionImportAccepted:
+      description: 'Result of an accepted collection import. Includes the url of the import task'
       content:
         application/json:
           schema:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -27,6 +27,8 @@ tags:
     description: 'API used by mazer and or ansible-galaxy'
   - name: 'introspection'
     description: 'API used to gather information about the API itself'
+  - name: 'v3'
+    description: 'API endpoints from the v3 API'
   - name: 'v2'
     description: 'API endpoints from the v2 API'
   - name: 'notifications'
@@ -108,6 +110,52 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/Namespaces'
+    post:
+      operationId: 'CreateNamespace'
+      summary: 'Create a Namespace'
+      parameters: []
+      requestBody:
+        $ref: '#/components/requestBodies/Namespace'
+      responses:
+        '201':
+            $ref: '#/components/responses/Namespace'
+      tags:
+        - namespaces
+        - v3
+
+  '/namespaces/{namespace_id}/':
+    get:
+      summary: 'Get a Namespace'
+      operationId: GetNamespace
+      parameters:
+        - $ref: '#/components/parameters/NamespaceId'
+      tags:
+        - namespaces
+        - v3
+      responses:
+        '200':
+            $ref: '#/components/responses/Namespace'
+    patch:
+      summary: 'Update a Namespace'
+      operationId: 'UpdateNamespace'
+      requestBody:
+        $ref: '#/components/requestBodies/Namespace'
+      responses:
+        '200':
+            $ref: '#/components/responses/Namespace'
+      tags:
+        - namespaces
+        - v3
+    delete:
+      summary: 'Delete a Namespace'
+      operationId: DeleteNamespace
+      responses:
+        '204':
+          $ref: '#/components/responses/SuccessfulDeletion'
+      tags:
+        - namespaces
+        - v3
+
 
   '/search/content/':
     get:
@@ -1252,6 +1300,9 @@ components:
           schema:
             $ref: '#/components/schemas/APIException'
 
+    SuccessfulDeletion:
+      description: 'A DELETE operation was successful'
+
     CollectionVersions:
       description: 'Response containing a page of CollectionVersionLinks'
       content:
@@ -1298,6 +1349,13 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CollectionCreationResult'
+
+    Namespace:
+      description: 'Result of creating a Namespace'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Namespace'
 
     Contents:
       description: 'Response containing a Page of Content search results'
@@ -1371,6 +1429,14 @@ components:
       schema:
         type: string
 
+    NamespaceId:
+      description: 'The Namespace id'
+      in: path
+      name: id
+      required: true
+      schema:
+        type: string
+
     CollectionNamespace:
       description: 'The collection namespace'
       in: path
@@ -1412,6 +1478,13 @@ components:
         multipart/form-data:
           schema:
             $ref: '#/components/schemas/CollectionVersionArtifactData'
+
+    Namespace:
+      description: "A Namespace body"
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Namespace'
 
   securitySchemes:
     BasicAuth:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -5,6 +5,7 @@ info:
   contact:
     url: https://github.com/ansible/galaxy/issues
     name: 'Ansible Galaxy Issues'
+    email: notreal@example.invalid
 
 openapi: 3.0.0
 
@@ -13,6 +14,7 @@ servers:
     description: 'local dev server'
 
 externalDocs:
+  description: 'General docs about Ansible Galaxy'
   url: https://galaxy.ansible.com/docs/
 
 tags:
@@ -21,8 +23,11 @@ tags:
       url: https://galaxy.ansible.com/docs/contributing/creating_collections.html
       description: 'Creating Collections docs at galaxy.ansible.com'
   - name: 'collection-imports'
+    description: 'Importing Collections'
   - name: 'collection-versions'
+    description: 'Versions of Collections'
   - name: 'download'
+    description: 'Downloading artifacts'
   - name: 'client_mazer'
     description: 'API used by mazer and or ansible-galaxy'
   - name: 'introspection'
@@ -31,14 +36,16 @@ tags:
     description: 'API endpoints from the v3 API'
   - name: 'v2'
     description: 'API endpoints from the v2 API'
-  - name: 'notifications'
   - name: 'me'
     description: 'API related to the current user.'
   - name: 'search'
+    description: 'API for searching'
   - name: 'namespaces'
+    description: 'API for Namespaces'
   - name: 'tags'
     description: 'API for Ansible Galaxy tags.'
   - name: 'users'
+    description: 'API for Users'
   - name: 'v1'
     description: 'API endpoints from the v1 API.'
 
@@ -83,7 +90,6 @@ paths:
         - me
         - v1
       security:
-        - TokenAuth: []
         - TokenApiKey: []
         - BasicAuth: []
       parameters:
@@ -123,7 +129,7 @@ paths:
         - namespaces
         - v3
 
-  '/namespaces/{namespace_id}/':
+  '/namespaces/{id}/':
     get:
       summary: 'Get a Namespace'
       operationId: GetNamespace
@@ -138,6 +144,8 @@ paths:
     patch:
       summary: 'Update a Namespace'
       operationId: 'UpdateNamespace'
+      parameters:
+        - $ref: '#/components/parameters/NamespaceId'
       requestBody:
         $ref: '#/components/requestBodies/Namespace'
       responses:
@@ -149,6 +157,8 @@ paths:
     delete:
       summary: 'Delete a Namespace'
       operationId: DeleteNamespace
+      parameters:
+        - $ref: '#/components/parameters/NamespaceId'
       responses:
         '204':
           $ref: '#/components/responses/SuccessfulDeletion'
@@ -173,6 +183,7 @@ paths:
 
   '/search/roles/':
     get:
+      summary: 'Get a list of Roles by searching'
       operationId: ListRoleBySearch
       tags:
         - search
@@ -319,6 +330,7 @@ paths:
 
   '/collection-versions/{id}/artifact/':
     get:
+      summary: 'Get a CollectionVersionArtifact'
       operationId: GetCollectionVersionArtifactById
       tags:
         - collection-versions
@@ -362,7 +374,6 @@ paths:
         - v2
         - client_mazer
       security:
-        - TokenAuth: []
         - TokenApiKey: []
         - BasicAuth: []
       parameters: []

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1396,41 +1396,6 @@ components:
 
 
   responses:
-    Conflict:
-      description: 'Conflict Error'
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: '#/components/schemas/ConflictError'
-            discriminator:
-              propertyName: code
-              mapping:
-                conflict: '#/components/schemas/ConflictError'
-                conflict.collection_exists: '#/components/schemas/ConflictCollectionExistsError'
-                conflict.repository_name_conflict: '#/compontents/schemas/RepositoryNameError'
-                conflict.artifact_exists: '#/compontents/schemas/ArtifactExistsError'
-
-    Unauthorized:
-      description: 'Authorization error'
-      headers:
-        WWW-Authenticate:
-          schema:
-            type: string
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/APIException'
-
-    NotFound:
-      description: 'Not Found (404)'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/APIException'
-
-    DeleteSuccessful:
-      description: 'A DELETE operation was successful'
 
     CollectionImportAccepted:
       description: 'Result of an accepted collection import. Includes the url of the import task'
@@ -1479,7 +1444,20 @@ components:
           schema:
             $ref: '#/components/schemas/CollectionVersionArtifactDetail'
 
-
+    Conflict:
+      description: 'Conflict Error'
+      content:
+        application/json:
+          schema:
+            oneOf:
+              - $ref: '#/components/schemas/ConflictError'
+            discriminator:
+              propertyName: code
+              mapping:
+                conflict: '#/components/schemas/ConflictError'
+                conflict.collection_exists: '#/components/schemas/ConflictCollectionExistsError'
+                conflict.repository_name_conflict: '#/compontents/schemas/RepositoryNameError'
+                conflict.artifact_exists: '#/compontents/schemas/ArtifactExistsError'
 
     Contents:
       description: 'Response containing a Page of Content search results'
@@ -1488,12 +1466,8 @@ components:
           schema:
             $ref: '#/components/schemas/ContentsPage'
 
-    Users:
-      description: 'Response containing a Page of a list of Users'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/UsersPage'
+    DeleteSuccessful:
+      description: 'A DELETE operation was successful'
 
     Namespace:
       description: 'Result of creating a Namespace'
@@ -1508,6 +1482,13 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/NamespacesPage'
+
+    NotFound:
+      description: 'Not Found (404)'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/APIException'
 
     ProviderNamespace:
       description: 'Result of creating a Provider Namespace'
@@ -1536,6 +1517,24 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/TagsPage'
+
+    Unauthorized:
+      description: 'Authorization error'
+      headers:
+        WWW-Authenticate:
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/APIException'
+
+    Users:
+      description: 'Response containing a Page of a list of Users'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UsersPage'
 
   parameters:
     Page:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -259,6 +259,82 @@ paths:
         '200':
           $ref: '#/components/responses/CollectionVersion'
 
+  '/collection-version-artifacts/':
+    get:
+      summary: 'Get a list of Collection Version artifacts'
+      operationId: GetCollectionVersionArtifacts
+      tags:
+        - collection-version-artifacts
+        - v3
+      responses:
+        '200':
+          $ref: '#/components/responses/CollectionVersionArtifacts'
+
+    post:
+      summary: 'Create a new CollectionVersionArtifact by uploading collection artifact'
+      operationId: UploadCollectionVersionArtifact
+      description: 
+        Create a new CollectionVersionArtifact by uploading a collection artifact.
+        This will add the new artifact, but will not create a new Collection.
+        To create a CollectionVersionArtifact and a Collection, use 'POST /collections'
+      tags:
+        - v3
+        - collection-version-artifacts
+      security:
+        - TokenApiKey: []
+        - BasicAuth: []
+      parameters: []
+      requestBody:
+        $ref: '#/components/requestBodies/CollectionVersionArtifactBody'
+      responses:
+        '202':
+          $ref: '#/components/responses/CollectionImportAccepted'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        default:
+          description: 'Unexpected Error'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  '/collection-version-artifacts/{artifact_id}':
+    get:
+      summary: 'Get a Collection Version artifacts'
+      operationId: GetCollectionVersionArtifact
+      tags:
+        - collection-version-artifacts
+        - v3
+      responses:
+        '200':
+          $ref: '#/components/responses/CollectionVersionArtifact'
+
+  '/collection-version-artifacts/{artifact_id}/download':
+    get:
+      summary: 'Download a Collection Version artifact'
+      operationId: DownloadCollectionVersionArtifact
+      tags:
+        - collection-version-artifacts
+        - v3
+      responses:
+        '200':
+          $ref: '#/components/responses/CollectionVersionArtifactDownload'
+
+  '/collection-version-artifacts/filenames/{filename}':
+    get:
+      summary: 'Get Collection Version Artifact info by filename'
+      operationId: GetCollectionVersionArtifactByFilename
+      parameters:
+        - $ref: '#/components/parameters/CollectionVersionArtifactFilename'
+      tags:
+        - collection-version-artifacts
+        - v3
+      responses:
+        '200':
+          $ref: '#/components/responses/CollectionVersionArtifact'
+
   '/download/{filename}':
     get:
       summary: 'Download the collection artifact'
@@ -267,20 +343,10 @@ paths:
         - download
         - client_mazer
       parameters:
-        - description: 'CollectionVersion artifact filename'
-          in: path
-          name: filename
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/CollectionVersionArtifactFilename'
       responses:
         '200':
-          description: 'The collection artifact file binary contents'
-          content:
-            application/octet-stream:
-              schema:
-                type: string
-                format: binary
+          $ref: '#/components/responses/CollectionVersionArtifactDownload'
 
   '/me/':
     get:
@@ -819,6 +885,7 @@ components:
 
     CollectionVersionArtifactDetail:
       type: object
+      title: 'CollectionVersionArtifactDetail'
       properties:
         download_url:
           readOnly: true
@@ -830,6 +897,21 @@ components:
           type: string
         size:
           type: integer
+
+    CollectionVersionArtifactsPage:
+      description: 'A page of a list of CollectionVersionArtifacts'
+      allOf:
+        - $ref: '#/components/schemas/PageInfo'
+        - type: object
+          properties:
+            results:
+              description: 'List of CollectionVersionArtifacts for this Page'
+              title: 'CollectionVersionArtifacts'
+              type: array
+              items:
+                $ref: '#/components/schemas/CollectionVersionArtifactDetail'
+          required:
+            - results
 
     CollectionVersionDependencies:
       description: 'A map of collection namespace.name to a semantic version'
@@ -1453,6 +1535,23 @@ components:
           schema:
             $ref: '#/components/schemas/CollectionVersionArtifactDetail'
 
+    CollectionVersionArtifacts:
+      description: 'Response containing a page of CollectionVersionArtifacts'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CollectionVersionArtifactsPage'
+
+    CollectionVersionArtifactDownload:
+      description: 'The collection artifact file binary contents'
+      content:
+        application/octet-stream:
+          schema:
+            title: 'CollectionVersionArtifactDownload'
+            description: 'The collection artifact file binary contents'
+            type: string
+            format: binary
+
     Conflict:
       description: 'Conflict Error'
       content:
@@ -1579,6 +1678,14 @@ components:
       schema:
         type: string
         pattern: ^((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$
+
+    CollectionVersionArtifactFilename:
+      description: 'CollectionVersion artifact filename'
+      in: path
+      name: filename
+      required: true
+      schema:
+        type: string
 
     NamespaceId:
       description: 'The Namespace id'

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -334,7 +334,8 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/CollectionVersionArtifact'
-  '/content/ansible/collections/':
+  '/pulp/content/ansible/collections/':
+    description: 'Wrapper API for /pulp/api/v3/content/ansible/collections/'
     get:
       tags:
         - collections
@@ -695,13 +696,16 @@ paths:
               schema:
                 $ref: '#/components/schemas/Tag'
 
-  /pulp/api/v3/tasks/:
+  # Could just make this /tasks/
+  '/pulp/tasks/':
+    description: 'Wrapper API for Pulp tasks API'
     get:
       tags:
         - tasks
         - pulp
         - v3
       summary: List tasks
+      description: 'Wrapper for Pulp API GET /pulp/api/v3/tasks/'
       operationId: GetPulpTasks
       parameters:
         - name: ordering
@@ -841,18 +845,20 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/PulpTask'
-  '/{task_href}':
+  '/pulp/tasks/{pulp_task_id}':
+    description: 'Wrapper API for Pulp {task_href}'
     get:
       tags:
         - tasks
         - pulp
         - v3
       summary: Inspect a task
+      description: "Wrapper API for Pulp GET {task_href} aka GET /pulp/api/v3/tasks/{task_id}"
       operationId: GetPulpTask
       parameters:
-        - name: task_href
+        - name: pulp_task_id
           in: path
-          description: 'URI of Task. e.g.: /pulp/api/v3/tasks/1/'
+          description: 'ID of Task. e.g.: "1" in /pulp/api/v3/tasks/1/'
           required: true
           schema:
             type: string

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1537,52 +1537,8 @@ components:
             $ref: '#/components/schemas/UsersPage'
 
   parameters:
-    Page:
-      description: 'Page number within the paginated result set.'
-      in: query
-      name: page
-      required: false
-      schema:
-        type: integer
-        default: 1
-
-    PageSize:
-      description: 'Number of results to return per page.'
-      in: query
-      name: page_size
-      required: false
-      schema:
-        type: integer
-        default: 10
-        minimum: 0
-        maximum: 1000
-
-    Search:
-      description: 'Term to search for'
-      in: query
-      name: search
-      required: false
-      schema:
-        type: string
-
     CollectionId:
       description: 'The Collection id'
-      in: path
-      name: id
-      required: true
-      schema:
-        type: string
-
-    NamespaceId:
-      description: 'The Namespace id'
-      in: path
-      name: id
-      required: true
-      schema:
-        type: string
-
-    ProviderNamespaceId:
-      description: 'The Provider Namespace id'
       in: path
       name: id
       required: true
@@ -1614,6 +1570,50 @@ components:
       schema:
         type: string
         pattern: ^((([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$
+
+    NamespaceId:
+      description: 'The Namespace id'
+      in: path
+      name: id
+      required: true
+      schema:
+        type: string
+
+    Page:
+      description: 'Page number within the paginated result set.'
+      in: query
+      name: page
+      required: false
+      schema:
+        type: integer
+        default: 1
+
+    PageSize:
+      description: 'Number of results to return per page.'
+      in: query
+      name: page_size
+      required: false
+      schema:
+        type: integer
+        default: 10
+        minimum: 0
+        maximum: 1000
+
+    ProviderNamespaceId:
+      description: 'The Provider Namespace id'
+      in: path
+      name: id
+      required: true
+      schema:
+        type: string
+
+    Search:
+      description: 'Term to search for'
+      in: query
+      name: search
+      required: false
+      schema:
+        type: string
 
     UserId:
       description: 'User id'

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -361,7 +361,7 @@ paths:
         - $ref: '#/components/parameters/NamespaceId'
       responses:
         '204':
-          $ref: '#/components/responses/SuccessfulDeletion'
+          $ref: '#/components/responses/DeleteSuccessful'
       tags:
         - namespaces
         - v3
@@ -427,7 +427,7 @@ paths:
         - $ref: '#/components/parameters/ProviderNamespaceId'
       responses:
         '204':
-          $ref: '#/components/responses/SuccessfulDeletion'
+          $ref: '#/components/responses/DeleteSuccessful'
       tags:
         - provider_namespaces
         - v3
@@ -1429,8 +1429,15 @@ components:
           schema:
             $ref: '#/components/schemas/APIException'
 
-    SuccessfulDeletion:
+    DeleteSuccessful:
       description: 'A DELETE operation was successful'
+
+    CollectionImportAccepted:
+      description: 'Result of an accepted collection import. Includes the url of the import task'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CollectionCreationResult'
 
     CollectionVersions:
       description: 'Response containing a page of CollectionVersionLinks'
@@ -1472,12 +1479,7 @@ components:
           schema:
             $ref: '#/components/schemas/CollectionVersionArtifactDetail'
 
-    CollectionImportAccepted:
-      description: 'Result of an accepted collection import. Includes the url of the import task'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/CollectionCreationResult'
+
 
     Contents:
       description: 'Response containing a Page of Content search results'

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -10,7 +10,7 @@ info:
 openapi: 3.0.0
 
 servers:
-  - url: http://localhost:5001/api/v3/
+  - url: http://localhost:5001/api/v3
     description: 'local dev server'
 
 externalDocs:
@@ -166,6 +166,71 @@ paths:
         - namespaces
         - v3
 
+  '/provider_namespaces/':
+    get:
+      summary: 'Get Provider Namespaces'
+      operationId: GetProviderNamespaces
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          $ref: '#/components/responses/ProviderNamespaces'
+      tags:
+        - provider_namespaces
+        - v3
+    post:
+      operationId: CreateProviderNamespace
+      summary: 'Create a Provider Namespace'
+      parameters: []
+      requestBody:
+        $ref: '#/components/requestBodies/ProviderNamespace'
+      responses:
+        '201':
+            $ref: '#/components/responses/ProviderNamespace'
+      tags:
+        - provider_namespaces
+        - v3
+
+  '/provider_namespaces/{id}/':
+    get:
+      operationId: GetProviderNamespace
+      description: 'Get a Provider Namespace'
+      parameters:
+        - $ref: '#/components/parameters/ProviderNamespaceId'
+      responses:
+        '200':
+          $ref: '#/components/responses/ProviderNamespace'
+      tags:
+        - provider_namespaces
+        - v3
+
+    patch:
+      operationId: UpdateProviderNamespace
+      description: 'Update a Provider Namespace'
+      parameters:
+        - $ref: '#/components/parameters/ProviderNamespaceId'
+      requestBody:
+        $ref: '#/components/requestBodies/ProviderNamespace'
+      responses:
+        '200':
+          $ref: '#/components/responses/ProviderNamespace'
+      tags:
+        - provider_namespaces
+        - v3
+
+    delete:
+      operationId: DeleteProviderNamespace
+      description: 'Delete a Provider Namespace'
+      parameters:
+        - $ref: '#/components/parameters/ProviderNamespaceId'
+      responses:
+        '204':
+          $ref: '#/components/responses/SuccessfulDeletion'
+      tags:
+        - provider_namespaces
+        - v3
 
   '/search/content/':
     get:
@@ -1058,6 +1123,43 @@ components:
           required:
             - name
 
+    ProviderNamespace:
+      description: 'A Provider Namespace'
+      allOf:
+        - $ref: '#/components/schemas/V1BaseModel'
+        - type: object
+          properties:
+            avatar_url:
+              maxLength: 256
+              nullable: true
+              type: string
+            company:
+              maxLength: 256
+              nullable: true
+              type: string
+            description:
+              maxLength: 255
+              type: string
+            email:
+              maxLength: 256
+              nullable: true
+              type: string
+            html_url:
+              maxLength: 256
+              nullable: true
+              type: string
+            is_vendor:
+              type: boolean
+            location:
+              maxLength: 256
+              nullable: true
+              type: string
+            name:
+              maxLength: 512
+              type: string
+          required:
+            - name
+
     Role:
       description: 'An Ansible Role'
       allOf:
@@ -1228,6 +1330,22 @@ components:
           items:
             $ref: '#/components/schemas/Namespace'
 
+    ProviderNamespacesPage:
+      description: 'A page of a list of Provider Namespaces'
+      type: object
+      properties:
+        count:
+          $ref: '#/components/schemas/PageCount'
+        next:
+          $ref: '#/components/schemas/PageNext'
+        previous:
+          $ref: '#/components/schemas/PagePrevious'
+        results:
+          description: 'List of Provider Namespaces'
+          type: array
+          items:
+            $ref: '#/components/schemas/ProviderNamespace'
+
     RolesPage:
       description: "A Page of a list of Roles"
       type: object
@@ -1361,13 +1479,6 @@ components:
           schema:
             $ref: '#/components/schemas/CollectionCreationResult'
 
-    Namespace:
-      description: 'Result of creating a Namespace'
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Namespace'
-
     Contents:
       description: 'Response containing a Page of Content search results'
       content:
@@ -1382,12 +1493,33 @@ components:
           schema:
             $ref: '#/components/schemas/UsersPage'
 
+    Namespace:
+      description: 'Result of creating a Namespace'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Namespace'
+
     Namespaces:
       description: 'Response containing a Page of a list of Namespaces'
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/NamespacesPage'
+
+    ProviderNamespace:
+      description: 'Result of creating a Provider Namespace'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ProviderNamespace'
+
+    ProviderNamespaces:
+      description: 'Response containing a Page of a list of Provider Namespaces'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ProviderNamespacesPage'
 
     Roles:
       description: 'Response containing a Page of a list of Roles'
@@ -1448,6 +1580,14 @@ components:
       schema:
         type: string
 
+    ProviderNamespaceId:
+      description: 'The Provider Namespace id'
+      in: path
+      name: id
+      required: true
+      schema:
+        type: string
+
     CollectionNamespace:
       description: 'The collection namespace'
       in: path
@@ -1496,6 +1636,13 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Namespace'
+
+    ProviderNamespace:
+      description: "A Provider Namespace body"
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ProviderNamespace'
 
   securitySchemes:
     BasicAuth:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -65,22 +65,222 @@ paths:
               schema:
                 $ref: '#/components/schemas/APIEndpoints'
 
-  '/search/':
-    get:
-      summary: 'Get info about the search API'
-      operationId: GetApiSearch
+  '/collections/':
+    post:
+      summary: 'Create a new CollectionVersion by importing a collection artifact'
+      operationId: ImportCollectionVersionArtifact
       tags:
-        - search
-        - introspection
-        - v1
+        - collections
+        - v2
+        - client_mazer
+      security:
+        - TokenApiKey: []
+        - BasicAuth: []
       parameters: []
+      requestBody:
+        $ref: '#/components/requestBodies/CollectionVersionArtifactBody'
       responses:
-        '200':
-          description: 'A map of endpoints in the search API'
+        '202':
+          $ref: '#/components/responses/CreateCollectionResult'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        default:
+          description: 'Unexpected Error'
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/APIEndpoints'
+                $ref: '#/components/schemas/Error'
+
+  '/collections/{id}/':
+    get:
+      summary: 'Get a Collection by id'
+      operationId: GetCollectionById
+      tags:
+        - collections
+        - v2
+      parameters:
+        - $ref: '#/components/parameters/CollectionId'
+      responses:
+        '200':
+          description: 'A Collection'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+
+  '/collections/{id}/versions/':
+    get:
+      summary: 'Get list of versions for a collection id'
+      operationId: ListCollectionVersionsById
+      tags:
+        - collections
+        - v2
+      parameters:
+        - $ref: '#/components/parameters/CollectionId'
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          $ref: '#/components/responses/CollectionVersions'
+
+  '/collections/{namespace}/{name}/':
+    parameters:
+      - $ref: '#/components/parameters/CollectionNamespace'
+      - $ref: '#/components/parameters/CollectionName'
+    get:
+      summary: 'Get a Collection by namespace and name'
+      operationId: GetCollectionByNamespaceName
+      tags:
+        - collections
+        - v2
+        - client_mazer
+      responses:
+        '200':
+          description: 'A Collection'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
+
+  '/collections/{namespace}/{name}/versions/':
+    parameters:
+      - $ref: '#/components/parameters/CollectionNamespace'
+      - $ref: '#/components/parameters/CollectionName'
+    get:
+      summary: 'Get a list of CollectionVersions for a Collection by namespace and name'
+      operationId: ListCollectionVersionsByNamespaceName
+      tags:
+        - collections
+        - v2
+        - client_mazer
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          $ref: '#/components/responses/CollectionVersions'
+
+  '/collections/{namespace}/{name}/versions/{version}/':
+    parameters:
+      - $ref: '#/components/parameters/CollectionNamespace'
+      - $ref: '#/components/parameters/CollectionName'
+      - $ref: '#/components/parameters/CollectionVersion'
+    get:
+      summary: 'Get a CollectionVersion by namespace, name, and version'
+      operationId: GetCollectionVersion
+      tags:
+        - collections
+        - v2
+        - client_mazer
+      responses:
+        '200':
+          $ref: '#/components/responses/CollectionVersion'
+
+  '/collections/{namespace}/{name}/versions/{version}/artifact/':
+    parameters:
+      - $ref: '#/components/parameters/CollectionNamespace'
+      - $ref: '#/components/parameters/CollectionName'
+      - $ref: '#/components/parameters/CollectionVersion'
+    get:
+      summary: 'Get Artifact details for a Collection by namespace, name, and version'
+      operationId: GetCollectionVersionArtifact
+      tags:
+        - collections
+        - v2
+        - client_mazer
+      parameters:
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          $ref: '#/components/responses/CollectionVersionArtifact'
+
+
+  '/collection-imports/{id}/':
+    get:
+      summary: 'Get a Collection-Import (import task) by id'
+      operationId: GetCollectionImportById
+      tags:
+        - collection-imports
+        - v2
+      parameters:
+        - description: 'A unique integer value identifying this collection import.'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          description: 'The result of a collection import'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CollectionImportResult'
+
+  '/collection-versions/{id}/artifact/':
+    get:
+      summary: 'Get a CollectionVersionArtifact'
+      operationId: GetCollectionVersionArtifactById
+      tags:
+        - collection-versions
+        - v2
+      parameters:
+        - description: 'The CollectionVersion id'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - $ref: '#/components/parameters/Search'
+      responses:
+        '200':
+          $ref: '#/components/responses/CollectionVersionArtifact'
+
+  '/collection-versions/{version_pk}/':
+    get:
+      summary: 'Get a CollectionVersion by version_pk'
+      operationId: GetCollectionVersionByVersionPk
+      tags:
+        - collection-versions
+        - v2
+      parameters:
+        - description: 'The CollectionVersion version_pk'
+          in: path
+          name: version_pk
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/CollectionVersion'
+
+  '/download/{filename}':
+    get:
+      summary: 'Download the collection artifact'
+      operationId: DownloadArtifactByFilename
+      tags:
+        - download
+        - client_mazer
+      parameters:
+        - description: 'CollectionVersion artifact filename'
+          in: path
+          name: filename
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: 'The collection artifact file binary contents'
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
 
   '/me/':
     get:
@@ -232,6 +432,23 @@ paths:
         - provider_namespaces
         - v3
 
+  '/search/':
+    get:
+      summary: 'Get info about the search API'
+      operationId: GetApiSearch
+      tags:
+        - search
+        - introspection
+        - v1
+      parameters: []
+      responses:
+        '200':
+          description: 'A map of endpoints in the search API'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/APIEndpoints'
+
   '/search/content/':
     get:
       summary: 'Get a list of Contents by searching'
@@ -369,222 +586,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/User'
-
-  '/collection-imports/{id}/':
-    get:
-      summary: 'Get a Collection-Import (import task) by id'
-      operationId: GetCollectionImportById
-      tags:
-        - collection-imports
-        - v2
-      parameters:
-        - description: 'A unique integer value identifying this collection import.'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - $ref: '#/components/parameters/Search'
-      responses:
-        '200':
-          description: 'The result of a collection import'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CollectionImportResult'
-
-  '/collection-versions/{id}/artifact/':
-    get:
-      summary: 'Get a CollectionVersionArtifact'
-      operationId: GetCollectionVersionArtifactById
-      tags:
-        - collection-versions
-        - v2
-      parameters:
-        - description: 'The CollectionVersion id'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: string
-        - $ref: '#/components/parameters/Search'
-      responses:
-        '200':
-          $ref: '#/components/responses/CollectionVersionArtifact'
-
-  '/collection-versions/{version_pk}/':
-    get:
-      summary: 'Get a CollectionVersion by version_pk'
-      operationId: GetCollectionVersionByVersionPk
-      tags:
-        - collection-versions
-        - v2
-      parameters:
-        - description: 'The CollectionVersion version_pk'
-          in: path
-          name: version_pk
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          $ref: '#/components/responses/CollectionVersion'
-
-  '/collections/':
-    post:
-      summary: 'Create a new CollectionVersion by importing a collection artifact'
-      operationId: ImportCollectionVersionArtifact
-      tags:
-        - collections
-        - v2
-        - client_mazer
-      security:
-        - TokenApiKey: []
-        - BasicAuth: []
-      parameters: []
-      requestBody:
-        $ref: '#/components/requestBodies/CollectionVersionArtifactBody'
-      responses:
-        '202':
-          $ref: '#/components/responses/CreateCollectionResult'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-        '409':
-          $ref: '#/components/responses/Conflict'
-        default:
-          description: 'Unexpected Error'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-
-  '/collections/{id}/':
-    get:
-      summary: 'Get a Collection by id'
-      operationId: GetCollectionById
-      tags:
-        - collections
-        - v2
-      parameters:
-        - $ref: '#/components/parameters/CollectionId'
-      responses:
-        '200':
-          description: 'A Collection'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Collection'
-
-  '/collections/{id}/versions/':
-    get:
-      summary: 'Get list of versions for a collection id'
-      operationId: ListCollectionVersionsById
-      tags:
-        - collections
-        - v2
-      parameters:
-        - $ref: '#/components/parameters/CollectionId'
-        - $ref: '#/components/parameters/Page'
-        - $ref: '#/components/parameters/PageSize'
-        - $ref: '#/components/parameters/Search'
-      responses:
-        '200':
-          $ref: '#/components/responses/CollectionVersions'
-
-  '/collections/{namespace}/{name}/':
-    parameters:
-      - $ref: '#/components/parameters/CollectionNamespace'
-      - $ref: '#/components/parameters/CollectionName'
-    get:
-      summary: 'Get a Collection by namespace and name'
-      operationId: GetCollectionByNamespaceName
-      tags:
-        - collections
-        - v2
-        - client_mazer
-      responses:
-        '200':
-          description: 'A Collection'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Collection'
-
-  '/collections/{namespace}/{name}/versions/':
-    parameters:
-      - $ref: '#/components/parameters/CollectionNamespace'
-      - $ref: '#/components/parameters/CollectionName'
-    get:
-      summary: 'Get a list of CollectionVersions for a Collection by namespace and name'
-      operationId: ListCollectionVersionsByNamespaceName
-      tags:
-        - collections
-        - v2
-        - client_mazer
-      parameters:
-        - $ref: '#/components/parameters/Page'
-        - $ref: '#/components/parameters/PageSize'
-        - $ref: '#/components/parameters/Search'
-      responses:
-        '200':
-          $ref: '#/components/responses/CollectionVersions'
-
-  '/collections/{namespace}/{name}/versions/{version}/':
-    parameters:
-      - $ref: '#/components/parameters/CollectionNamespace'
-      - $ref: '#/components/parameters/CollectionName'
-      - $ref: '#/components/parameters/CollectionVersion'
-    get:
-      summary: 'Get a CollectionVersion by namespace, name, and version'
-      operationId: GetCollectionVersion
-      tags:
-        - collections
-        - v2
-        - client_mazer
-      responses:
-        '200':
-          $ref: '#/components/responses/CollectionVersion'
-
-  '/collections/{namespace}/{name}/versions/{version}/artifact/':
-    parameters:
-      - $ref: '#/components/parameters/CollectionNamespace'
-      - $ref: '#/components/parameters/CollectionName'
-      - $ref: '#/components/parameters/CollectionVersion'
-    get:
-      summary: 'Get Artifact details for a Collection by namespace, name, and version'
-      operationId: GetCollectionVersionArtifact
-      tags:
-        - collections
-        - v2
-        - client_mazer
-      parameters:
-        - $ref: '#/components/parameters/Search'
-      responses:
-        '200':
-          $ref: '#/components/responses/CollectionVersionArtifact'
-
-  '/download/{filename}':
-    get:
-      summary: 'Download the collection artifact'
-      operationId: DownloadArtifactByFilename
-      tags:
-        - download
-        - client_mazer
-      parameters:
-        - description: 'CollectionVersion artifact filename'
-          in: path
-          name: filename
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: 'The collection artifact file binary contents'
-          content:
-            application/octet-stream:
-              schema:
-                type: string
-                format: binary
 
 components:
   schemas:
@@ -737,7 +738,6 @@ components:
 
     CollectionImportMessage:
       description: 'Message from collection importer including lint results'
-
       type: object
       properties:
         level:


### PR DESCRIPTION
Start of an openapi.yaml to describe the 'v3' API.

Mostly still based on https://github.com/alikins/galaxy-api-swaggerhub

Some changes:
- /api/v* is now part of the server url, so the paths look like '/namespaces/' or 'collections/'
- rough out the current security/authz though that will change
- added /namespaces/  CRUD stuff

Not included yet:
- any pagination or error formatting changes
- model changes related to the looser coupling between:
 - Collection, CollectionVersion and CollectionVersionArtifacts
 - Namespaces and Collection*
- User model changes
- api endpoints that are analogs to pulp apis