### PR TITLE
Add generic Error and ErrorItem schemas  (galaxy-dev#32)

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -21,7 +21,7 @@ paths:
         '200':
           description: A paginated list of namespaces
         'default':
-          description: Error
+          $ref: '#/components/responses/Error'
     post:
       summary: Create a namespace
       tags:
@@ -30,7 +30,7 @@ paths:
         '201':
           description: Namespace created successfully
         'default':
-          description: Error
+          $ref: '#/components/responses/Error'
 
   '/namespaces/{name}/':
     get:
@@ -42,7 +42,7 @@ paths:
         '200':
           description: The requested Namespace
         'default':
-          description: Error
+          $ref: '#/components/responses/Error'
     put:
       summary: Update Namespace
       operationId: updateNamespace
@@ -52,7 +52,7 @@ paths:
         '200':
           description: Namespace updated successfully
         'default':
-          description: Error
+          $ref: '#/components/responses/Error'
     delete:
       summary: Delete Namespace
       operationId: deleteNamespace
@@ -62,7 +62,7 @@ paths:
         '204':
           description: Namespace deleted successfully
         'default':
-          description: Error
+          $ref: '#/components/responses/Error'
 
 # -------------------------------------
 # Collections
@@ -77,7 +77,7 @@ paths:
         '200':
           description: A paginated list of collections
         'default':
-          description: Error
+          $ref: '#/components/responses/Error'
     post:
       summary: Upload Collection
       operationId: uploadCollection
@@ -94,8 +94,7 @@ paths:
         '200':
           description: The requested Collection
         'default':
-          description: Error
-
+          $ref: '#/components/responses/Error'
 
     put:
       summary: Update Collection
@@ -113,7 +112,7 @@ paths:
         '200':
           description: A paginated list of Collection Versions
         'default':
-          description: Error
+          $ref: '#/components/responses/Error'
 
   '/collections/{namespace}/{name}/versions/{version}/':
     get:
@@ -125,7 +124,7 @@ paths:
         '200':
           description: The requested Collection Version
         'default':
-          description: Error
+          $ref: '#/components/responses/Error'
 
   '/collections/{namespace}/{name}/versions/{version}/artifact/':
     get:
@@ -137,7 +136,7 @@ paths:
         '200':
           description: The requested Collection Version Artifact
         'default':
-          description: Error
+          $ref: '#/components/responses/Error'
 
 # -------------------------------------
 # Imports
@@ -152,7 +151,7 @@ paths:
         '200':
           description: A paginated list of Collection Imports
         'default':
-          description: Error
+          $ref: '#/components/responses/Error'
 
   '/imports/collections/{id}/':
     get:
@@ -164,7 +163,7 @@ paths:
         '200':
           description: The requested Collection Import
         'default':
-          description: Error
+          $ref: '#/components/responses/Error'
 
 # -------------------------------------
 # Downloads
@@ -189,7 +188,7 @@ paths:
         '200':
           description: A paginated list of Collections
         'default':
-          description: Error
+          $ref: '#/components/responses/Error'
 
   '/search/tags/':
     get:
@@ -201,7 +200,7 @@ paths:
         '200':
           description: A paginated list of Tags
         'default':
-          description: Error
+          $ref: '#/components/responses/Error'
 
 # -------------------------------------
 # Users
@@ -216,7 +215,7 @@ paths:
         '200':
           description: A paginated list of Users
         'default':
-          description: Error
+          $ref: '#/components/responses/Error'
 
 
   '/users/{id}/':
@@ -229,7 +228,7 @@ paths:
         '200':
           description: The requested User
         'default':
-          description: Error
+          $ref: '#/components/responses/Error'
 
 
 # -------------------------------------
@@ -246,4 +245,64 @@ paths:
         '200':
           description: The current User
         'default':
-          description: Error
+          $ref: '#/components/responses/Error'
+
+components:
+  schemas:
+    Error:
+      title: 'Error'
+      description: "A JSON API Error object"
+      type: object
+      externalDocs:
+        description: 'JSON API Error Specification'
+        url: 'https://jsonapi.org/format/#errors'
+      properties:
+        errors:
+          type: array
+          title: 'ErrorItems'
+          items:
+            $ref: '#/components/schemas/ErrorItem'
+          minItems: 1
+      required:
+        - errors
+
+    ErrorItem:
+      title: 'ErrorItem'
+      description: 'An item returned in the Error "errors" value'
+      externalDocs:
+        description: 'JSON API Error Specification'
+        url: 'https://jsonapi.org/format/#errors'
+      type: object
+      properties:
+        code:
+          description: 'Unique identifier for the error'
+          type: string
+          example: 'not_found'
+        detail:
+          type: string
+          description: 'Error detail'
+          example: 'Record not found.'
+        status:
+          type: string
+          description: 'String representation of HTTP status code'
+          example: '404'
+        source:
+          type: object
+          properties:
+            parameter:
+              description: 'A string indicating which URI query parameter caused the error.'
+              type: string
+            pointer:
+              description: 'A JSON Pointer [RFC6901] to the associated entity in the request document '
+              type: string
+      required:
+        - detail
+        - status
+
+  responses:
+    Error:
+      description: 'Error'
+      content:
+        application/vnd.api+json:
+          schema:
+            $ref: '#/components/schemas/Error'

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -307,6 +307,6 @@ components:
     Errors:
       description: 'Errors'
       content:
-        application/vnd.api+json:
+        application/json:
           schema:
             $ref: '#/components/schemas/Errors'

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -280,7 +280,11 @@ components:
           example: 'not_found'
         detail:
           type: string
-          description: 'Error detail'
+          description: 'A human-readable explanation specific to this occurrence of the problem'
+          example: 'Record /unicorn/11 was not found'
+        title:
+          type: string
+          description: 'A short, human-readable summary of the problem'
           example: 'Record not found.'
         status:
           type: string

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -21,7 +21,7 @@ paths:
         '200':
           description: A paginated list of namespaces
         'default':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/Errors'
     post:
       summary: Create a namespace
       tags:
@@ -30,7 +30,7 @@ paths:
         '201':
           description: Namespace created successfully
         'default':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/Errors'
 
   '/namespaces/{name}/':
     get:
@@ -42,7 +42,7 @@ paths:
         '200':
           description: The requested Namespace
         'default':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/Errors'
     put:
       summary: Update Namespace
       operationId: updateNamespace
@@ -52,7 +52,7 @@ paths:
         '200':
           description: Namespace updated successfully
         'default':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/Errors'
     delete:
       summary: Delete Namespace
       operationId: deleteNamespace
@@ -62,7 +62,7 @@ paths:
         '204':
           description: Namespace deleted successfully
         'default':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/Errors'
 
 # -------------------------------------
 # Collections
@@ -77,7 +77,7 @@ paths:
         '200':
           description: A paginated list of collections
         'default':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/Errors'
     post:
       summary: Upload Collection
       operationId: uploadCollection
@@ -94,7 +94,7 @@ paths:
         '200':
           description: The requested Collection
         'default':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/Errors'
 
     put:
       summary: Update Collection
@@ -112,7 +112,7 @@ paths:
         '200':
           description: A paginated list of Collection Versions
         'default':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/Errors'
 
   '/collections/{namespace}/{name}/versions/{version}/':
     get:
@@ -124,7 +124,7 @@ paths:
         '200':
           description: The requested Collection Version
         'default':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/Errors'
 
   '/collections/{namespace}/{name}/versions/{version}/artifact/':
     get:
@@ -136,7 +136,7 @@ paths:
         '200':
           description: The requested Collection Version Artifact
         'default':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/Errors'
 
 # -------------------------------------
 # Imports
@@ -151,7 +151,7 @@ paths:
         '200':
           description: A paginated list of Collection Imports
         'default':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/Errors'
 
   '/imports/collections/{id}/':
     get:
@@ -163,7 +163,7 @@ paths:
         '200':
           description: The requested Collection Import
         'default':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/Errors'
 
 # -------------------------------------
 # Downloads
@@ -188,7 +188,7 @@ paths:
         '200':
           description: A paginated list of Collections
         'default':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/Errors'
 
   '/search/tags/':
     get:
@@ -200,7 +200,7 @@ paths:
         '200':
           description: A paginated list of Tags
         'default':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/Errors'
 
 # -------------------------------------
 # Users
@@ -215,7 +215,7 @@ paths:
         '200':
           description: A paginated list of Users
         'default':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/Errors'
 
 
   '/users/{id}/':
@@ -228,7 +228,7 @@ paths:
         '200':
           description: The requested User
         'default':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/Errors'
 
 
 # -------------------------------------
@@ -245,13 +245,13 @@ paths:
         '200':
           description: The current User
         'default':
-          $ref: '#/components/responses/Error'
+          $ref: '#/components/responses/Errors'
 
 components:
   schemas:
-    Error:
-      title: 'Error'
-      description: "A JSON API Error object"
+    Errors:
+      title: 'Errors'
+      description: "A list of JSON API Error objects"
       type: object
       externalDocs:
         description: 'JSON API Error Specification'
@@ -259,19 +259,19 @@ components:
       properties:
         errors:
           type: array
-          title: 'ErrorItems'
+          title: 'Errors'
           items:
-            $ref: '#/components/schemas/ErrorItem'
+            $ref: '#/components/schemas/Error'
           minItems: 1
       required:
         - errors
 
-    ErrorItem:
-      title: 'ErrorItem'
-      description: 'An item returned in the Error "errors" value'
+    Error:
+      title: 'Error'
+      description: "A JSON API Error object"
       externalDocs:
         description: 'JSON API Error Specification'
-        url: 'https://jsonapi.org/format/#errors'
+        url: 'https://jsonapi.org/format/#error-objects'
       type: object
       properties:
         code:
@@ -300,9 +300,9 @@ components:
         - status
 
   responses:
-    Error:
-      description: 'Error'
+    Errors:
+      description: 'Errors'
       content:
         application/vnd.api+json:
           schema:
-            $ref: '#/components/schemas/Error'
+            $ref: '#/components/schemas/Errors'


### PR DESCRIPTION
Add generic Error and ErrorItem schemas
    
Add NotFound/Unauthorized responses that use the
Error schema and add as examples to GET / for now.
    
Fixes https://github.com/ansible/galaxy-dev/issues/32
(at least as far as possible without actually defining
the real endpoints yet)
