### PR TITLE
Add 'servers' stanza with localhost for now

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -75,6 +75,9 @@ info:
     }
     ```
 
+servers:
+  - url: http://localhost:5001/api/v3
+    description: 'local sandbox'
 
 
 paths:


### PR DESCRIPTION
Enables swaggerui/redoc/etc to provide better
sample urls.