### PR TITLE
 OpenAPI: Add namespace resource fields

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -885,6 +885,9 @@ components:
           description: Namespace brief description
           type: string
           maxLength: 256
+        resource_page:
+          description: Namespace resource page in Markdown format.
+          type: string
         links:
           description: Related links
           type: array


### PR DESCRIPTION
Add the following fields to `Namespace` schema:
    - `resource_page`

DependsOn: #47