### PR TITLE
Remove ui import detail endpoint

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -320,20 +320,6 @@ paths:
         'default':
           $ref: '#/components/responses/Errors'
 
-  '/_ui/imports/collections/{import_id}':
-    get:
-      summary: Get collection import (UI)
-      operationId: getCollectionImportUi
-      tags:
-        - 'UI: Imports'
-      parameters:
-        - $ref: '#/components/parameters/CollectionImportId'
-      responses:
-        '200':
-          $ref: '#/components/responses/UiCollectionImport'
-        'default':
-          $ref: '#/components/responses/Errors'
-
 # -------------------------------------
 # UI: Namespaces
 # -------------------------------------


### PR DESCRIPTION
`/imports/collection/{id}` has all the information we need for the UI, so I'm getting rid of `_ui/imports/collection{id}` because it's redundant and missing critical information.