### PR TITLE
Return raw id field for collections and versions

### DIFF
--- a/galaxy_api/api/ui/serializers/collection.py
+++ b/galaxy_api/api/ui/serializers/collection.py
@@ -63,16 +63,13 @@ class CollectionVersionSerializer(CollectionMetadataBaseSerializer):
 
 
 class CollectionSerializer(serializers.Serializer):
-    id = serializers.SerializerMethodField()
+    id = serializers.UUIDField()
     namespace = serializers.SerializerMethodField()
     name = serializers.CharField()
     download_count = serializers.IntegerField(default=0)
 
     latest_version = CollectionLatestVersionSerializer(source='*')
     content_summary = ContentSummarySerializer(source='contents')
-
-    def get_id(self, obj):
-        return f"{obj['namespace']}.{obj['name']}"
 
     def get_namespace(self, obj):
         namespace = obj['namespace']


### PR DESCRIPTION
Passthrough CollectionVersion id field returned by pulp API.

depends on: pulp/pulp_ansible#191