### PR TITLE
Fix pagination in ui API

### DIFF
--- a/bindings/openapi.yaml
+++ b/bindings/openapi.yaml
@@ -31,11 +31,11 @@ paths:
           schema:
             type: boolean
         - in: query
-          name: page
+          name: offset
           schema:
             type: integer
         - in: query
-          name: page_size
+          name: limit
           schema:
             type: integer
       responses:
@@ -44,20 +44,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  count:
-                    type: integer
-                  next:
-                    type: string
-                    format: uri
-                  previous:
-                    type: string
-                    format: url
-                  results:
-                    type: array
-                    items:
-                      type: object
+                $ref: '#/components/schemas/ResultsPage'
 
   "/pulp/api/v3/content/ansible/collections/{id}":
     parameters:
@@ -100,11 +87,11 @@ paths:
           schema:
             type: string
         - in: query
-          name: page
+          name: offset
           schema:
             type: integer
         - in: query
-          name: page_size
+          name: limit
           schema:
             type: integer
       responses:
@@ -113,7 +100,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/ResultsPage'
 
   "/pulp/api/v3/pulp_ansible/imports/{id}/":
     parameters:
@@ -148,11 +135,11 @@ paths:
       tags: ["galaxy: collections"]
       parameters:
         - in: query
-          name: limit
+          name: offset
           schema:
             type: integer
         - in: query
-          name: offset
+          name: limit
           schema:
             type: integer
       responses:
@@ -161,7 +148,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/ResultsPage'
 
   "/{prefix}/v3/collections/{namespace}/{name}/":
     parameters:
@@ -211,13 +198,22 @@ paths:
     get:
       operationId: "list_versions"
       tags: ["galaxy: collections"]
+      parameters:
+        - in: query
+          name: offset
+          schema:
+            type: integer
+        - in: query
+          name: limit
+          schema:
+            type: integer
       responses:
         200:
           description: 'OK'
           content:
             application/json:
               schema:
-                type: object
+                $ref: '#/components/schemas/ResultsPage'
 
   "/{prefix}/v3/collections/{namespace}/{name}/versions/{version}/":
     parameters:
@@ -313,3 +309,20 @@ components:
     BasicAuth:
       type: http
       scheme: basic
+
+  schemas:
+    ResultsPage:
+      type: object
+      properties:
+        count:
+          type: integer
+        next:
+          type: string
+          format: uri
+        previous:
+          type: string
+          format: url
+        results:
+          type: array
+          items:
+            type: object

--- a/galaxy_api/api/pagination.py
+++ b/galaxy_api/api/pagination.py
@@ -59,7 +59,15 @@ class LimitOffsetPagination(pagination.LimitOffsetPagination):
         )
 
     # Custom methods for working with pulp client
-    def from_request(self, request):
+    def init_from_request(self, request):
         self.request = request
         self.offset = self.get_offset(request)
         self.limit = self.get_limit(request)
+
+    def paginate_proxy_response(self, data, count):
+        self.count = count
+
+        if self.count > self.limit and self.template is not None:
+            self.display_page_controls = True
+
+        return self.get_paginated_response(data)

--- a/galaxy_api/api/ui/serializers/__init__.py
+++ b/galaxy_api/api/ui/serializers/__init__.py
@@ -1,6 +1,7 @@
 from .namespace import NamespaceSerializer
 from .collection import (
-    CollectionSerializer,
+    CollectionDetailSerializer,
+    CollectionListSerializer,
     CollectionVersionSerializer,
     CollectionVersionBaseSerializer,
 )
@@ -8,7 +9,8 @@ from .collection import (
 
 __all__ = (
     'NamespaceSerializer',
-    'CollectionSerializer',
+    'CollectionDetailSerializer',
+    'CollectionListSerializer',
     'CollectionVersionSerializer',
     'CollectionVersionBaseSerializer',
 )

--- a/galaxy_api/api/ui/serializers/collection.py
+++ b/galaxy_api/api/ui/serializers/collection.py
@@ -62,7 +62,7 @@ class CollectionVersionSerializer(CollectionMetadataBaseSerializer):
     docs_blob = serializers.JSONField()
 
 
-class CollectionSerializer(serializers.Serializer):
+class _CollectionSerializer(serializers.Serializer):
     id = serializers.UUIDField()
     namespace = serializers.SerializerMethodField()
     name = serializers.CharField()
@@ -71,11 +71,21 @@ class CollectionSerializer(serializers.Serializer):
     latest_version = CollectionLatestVersionSerializer(source='*')
     content_summary = ContentSummarySerializer(source='contents')
 
-    def get_namespace(self, obj):
-        namespace = obj['namespace']
-        if 'namespace_dict' in self.context:
-            namespace = self.context['namespace_dict'][namespace]
-        else:
-            namespace = self.context['namespace']
+    def _get_namespace(self, obj):
+        raise NotImplementedError
 
+    def get_namespace(self, obj):
+        namespace = self._get_namespace(obj)
         return NamespaceSerializer(namespace).data
+
+
+class CollectionListSerializer(_CollectionSerializer):
+    def _get_namespace(self, obj):
+        name = obj['namespace']
+        return self.context['namespaces'][name]
+
+
+class CollectionDetailSerializer(_CollectionSerializer):
+
+    def _get_namespace(self, obj):
+        return self.context['namespace']

--- a/galaxy_api/api/v3/viewsets.py
+++ b/galaxy_api/api/v3/viewsets.py
@@ -22,12 +22,20 @@ from rest_framework import viewsets
 from galaxy_api.common import pulp
 
 
-class CollectionViewSet(viewsets.ViewSet):
+class CollectionViewSet(viewsets.GenericViewSet):
 
     def list(self, request, *args, **kwargs):
+        self.paginator.init_from_request(request)
+
+        params = self.request.query_params.dict()
+        params.update({
+            'offset': self.paginator.offset,
+            'limit': self.paginator.limit,
+        })
+
         api = galaxy_pulp.GalaxyCollectionsApi(pulp.get_client())
-        response = api.list(prefix=settings.API_PATH_PREFIX, **request.query_params.dict())
-        return Response(response)
+        response = api.list(prefix=settings.API_PATH_PREFIX, **params)
+        return self.paginator.paginate_proxy_response(response.results, response.count)
 
     def retrieve(self, request, *args, **kwargs):
         api = galaxy_pulp.GalaxyCollectionsApi(pulp.get_client())
@@ -39,17 +47,25 @@ class CollectionViewSet(viewsets.ViewSet):
         return Response(response)
 
 
-class CollectionVersionViewSet(viewsets.ViewSet):
+class CollectionVersionViewSet(viewsets.GenericViewSet):
 
     def list(self, request, *args, **kwargs):
+        self.paginator.init_from_request(request)
+
+        params = self.request.query_params.dict()
+        params.update({
+            'offset': self.paginator.offset,
+            'limit': self.paginator.limit,
+        })
+
         api = galaxy_pulp.GalaxyCollectionsApi(pulp.get_client())
         response = api.list_versions(
             prefix=settings.API_PATH_PREFIX,
             namespace=self.kwargs['namespace'],
             name=self.kwargs['name'],
-            **request.query_params.dict()
+            **params,
         )
-        return Response(response)
+        return self.paginator.paginate_proxy_response(response.results, response.count)
 
     def retrieve(self, request, *args, **kwargs):
         api = galaxy_pulp.GalaxyCollectionsApi(pulp.get_client())

--- a/tests/api/test_v3_collections.py
+++ b/tests/api/test_v3_collections.py
@@ -1,10 +1,11 @@
 import unittest
 from unittest import mock
 
+import galaxy_pulp
 from django.conf import settings
-from galaxy_api.auth.auth import RHEntitlementRequired
 from rest_framework.test import APIClient
 
+from galaxy_api.auth.auth import RHEntitlementRequired
 from galaxy_api.auth.models import User
 
 API_PREFIX = settings.API_PATH_PREFIX.strip("/")
@@ -34,21 +35,27 @@ class TestCollectionViewSet(BaseTestCase):
         self.addCleanup(patcher.stop)
 
     def test_list(self):
-        self.collection_api.list.return_value = {}
+        self.collection_api.list.return_value = galaxy_pulp.ResultsPage(
+            count=1, results=[]
+        )
         response = self.client.get(f"/{API_PREFIX}/v3/collections/")
 
         assert response.status_code == 200
-        self.collection_api.list.assert_called_once_with(prefix=API_PREFIX)
+        self.collection_api.list.assert_called_once_with(
+            prefix=API_PREFIX, offset=0, limit=10
+        )
 
     def test_list_limit_offset(self):
-        self.collection_api.list.return_value = {}
+        self.collection_api.list.return_value = galaxy_pulp.ResultsPage(
+            count=1, results=[]
+        )
         response = self.client.get(
             f"/{API_PREFIX}/v3/collections/", data={"limit": 10, "offset": 20}
         )
 
         assert response.status_code == 200
         self.collection_api.list.assert_called_once_with(
-            prefix=API_PREFIX, limit="10", offset="20"
+            prefix=API_PREFIX, limit=10, offset=20
         )
 
     def test_retrieve(self):
@@ -70,18 +77,22 @@ class TestCollectionVersionViewSet(BaseTestCase):
         self.addCleanup(patcher.stop)
 
     def test_list(self):
-        self.collection_api.list_versions.return_value = {}
+        self.collection_api.list_versions.return_value = galaxy_pulp.ResultsPage(
+            count=1, results=[]
+        )
         response = self.client.get(
             f"/{API_PREFIX}/v3/collections/ansible/nginx/versions/"
         )
 
         assert response.status_code == 200
         self.collection_api.list_versions.assert_called_once_with(
-            prefix=API_PREFIX, namespace="ansible", name="nginx"
+            prefix=API_PREFIX, namespace="ansible", name="nginx", limit=10, offset=0
         )
 
     def test_list_limit_offset(self):
-        self.collection_api.list_versions.return_value = {}
+        self.collection_api.list_versions.return_value = galaxy_pulp.ResultsPage(
+            count=1, results=[]
+        )
         response = self.client.get(
             f"/{API_PREFIX}/v3/collections/ansible/nginx/versions/",
             data={"limit": 10, "offset": 20},
@@ -89,11 +100,7 @@ class TestCollectionVersionViewSet(BaseTestCase):
 
         assert response.status_code == 200
         self.collection_api.list_versions.assert_called_once_with(
-            prefix=API_PREFIX,
-            namespace="ansible",
-            name="nginx",
-            limit="10",
-            offset="20",
+            prefix=API_PREFIX, namespace="ansible", name="nginx", limit=10, offset=20
         )
 
     def test_retrieve(self):
@@ -124,5 +131,5 @@ class TestCollectionImportViewSet(BaseTestCase):
 
         assert response.status_code == 200
         self.imports_api.get.assert_called_once_with(
-            prefix=API_PREFIX, id='3e26b82c-702f-4bdd-a568-7d9db17759c1'
+            prefix=API_PREFIX, id="3e26b82c-702f-4bdd-a568-7d9db17759c1"
         )


### PR DESCRIPTION
This patch fixes limit offset pagination in proxy API
endpoints related to latest changes in pulp pagination.

Fixes: ansible/galaxy-api#90
