### PR TITLE
Implement certified set \ unset endpoint

### DIFF
--- a/bindings/openapi.yaml
+++ b/bindings/openapi.yaml
@@ -46,7 +46,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ResultsPage'
 
-  "/pulp/api/v3/content/ansible/collections/{id}":
+  "/pulp/api/v3/content/ansible/collections/{id}/":
     parameters:
       - in: path
         name: id
@@ -147,7 +147,7 @@ paths:
                 $ref: '#/components/schemas/ResultsPage'
 
 
-  # Galaxy API
+  # Galaxy Collections API
   "/{prefix}/v3/collections/":
     parameters:
       - in: path
@@ -203,6 +203,7 @@ paths:
               schema:
                 type: object
 
+  # Galaxy Collection Versions API
   "/{prefix}/v3/collections/{namespace}/{name}/versions/":
     parameters:
       - in: path
@@ -221,8 +222,8 @@ paths:
         schema:
           type: string
     get:
-      operationId: "list_versions"
-      tags: ["galaxy: collections"]
+      operationId: "list"
+      tags: ["galaxy: collection versions"]
       parameters:
         - in: query
           name: offset
@@ -263,8 +264,8 @@ paths:
         schema:
           type: string
     get:
-      operationId: "get_version"
-      tags: ["galaxy: collections"]
+      operationId: "get"
+      tags: ["galaxy: collection versions"]
       responses:
         200:
           description: "OK"
@@ -273,6 +274,50 @@ paths:
               schema:
                 type: object
 
+  "/{prefix}/v3/collections/{namespace}/{name}/versions/{version}/certified/":
+    parameters:
+      - in: path
+        name: prefix
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: namespace
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: version
+        required: true
+        schema:
+          type: string
+    put:
+      operationId: "set_certified"
+      tags: ["galaxy: collection versions"]
+      responses:
+        200:
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: object
+    delete:
+      operationId: "unset_certified"
+      tags: ["galaxy: collection versions"]
+      responses:
+        200:
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: object
+
+  # Galaxy Artifacts API
   "/{prefix}/artifacts/collections/":
     parameters:
       - in: path
@@ -306,6 +351,7 @@ paths:
                     type: string
                     format: uri
 
+  # Galaxy Imports API
   "/{prefix}/imports/collections/{id}/":
     parameters:
       - in: path

--- a/galaxy_api/api/v3/viewsets.py
+++ b/galaxy_api/api/v3/viewsets.py
@@ -58,8 +58,8 @@ class CollectionVersionViewSet(viewsets.GenericViewSet):
             'limit': self.paginator.limit,
         })
 
-        api = galaxy_pulp.GalaxyCollectionsApi(pulp.get_client())
-        response = api.list_versions(
+        api = galaxy_pulp.GalaxyCollectionVersionsApi(pulp.get_client())
+        response = api.list(
             prefix=settings.API_PATH_PREFIX,
             namespace=self.kwargs['namespace'],
             name=self.kwargs['name'],
@@ -68,8 +68,8 @@ class CollectionVersionViewSet(viewsets.GenericViewSet):
         return self.paginator.paginate_proxy_response(response.results, response.count)
 
     def retrieve(self, request, *args, **kwargs):
-        api = galaxy_pulp.GalaxyCollectionsApi(pulp.get_client())
-        response = api.get_version(
+        api = galaxy_pulp.GalaxyCollectionVersionsApi(pulp.get_client())
+        response = api.get(
             prefix=settings.API_PATH_PREFIX,
             namespace=self.kwargs['namespace'],
             name=self.kwargs['name'],

--- a/tests/api/test_api_ui_collection_viewsets.py
+++ b/tests/api/test_api_ui_collection_viewsets.py
@@ -1,0 +1,40 @@
+from unittest import mock
+
+from .base import BaseTestCase, API_PREFIX
+
+
+class TestCollectionVersionViewSet(BaseTestCase):
+    def setUp(self):
+        super().setUp()
+
+        patcher = mock.patch("galaxy_pulp.GalaxyCollectionVersionsApi", spec=True)
+        self.versions_api = patcher.start().return_value
+        self.addCleanup(patcher.stop)
+
+    def test_set_certified(self):
+        self.versions_api.set_certified.return_value = {}
+
+        response = self.client.put(
+            f"/{API_PREFIX}/v3/_ui/collections/ansible/nginx/versions/1.2.3/certified/"
+        )
+
+        self.versions_api.set_certified.assert_called_once_with(
+            prefix=API_PREFIX, namespace="ansible", name="nginx", version="1.2.3"
+        )
+
+        assert response.status_code == 200
+        assert response.data == {}
+
+    def test_unset_certified(self):
+        self.versions_api.unset_certified.return_value = {}
+
+        response = self.client.delete(
+            f"/{API_PREFIX}/v3/_ui/collections/ansible/nginx/versions/1.2.3/certified/"
+        )
+
+        self.versions_api.unset_certified.assert_called_once_with(
+            prefix=API_PREFIX, namespace="ansible", name="nginx", version="1.2.3"
+        )
+
+        assert response.status_code == 200
+        assert response.data == {}

--- a/tests/api/test_api_v3_viewsets.py
+++ b/tests/api/test_api_v3_viewsets.py
@@ -51,12 +51,12 @@ class TestCollectionVersionViewSet(BaseTestCase):
     def setUp(self):
         super().setUp()
 
-        patcher = mock.patch("galaxy_pulp.GalaxyCollectionsApi")
-        self.collection_api = patcher.start().return_value
+        patcher = mock.patch("galaxy_pulp.GalaxyCollectionVersionsApi", spec=True)
+        self.versions_api = patcher.start().return_value
         self.addCleanup(patcher.stop)
 
     def test_list(self):
-        self.collection_api.list_versions.return_value = galaxy_pulp.ResultsPage(
+        self.versions_api.list.return_value = galaxy_pulp.ResultsPage(
             count=1, results=[]
         )
         response = self.client.get(
@@ -64,12 +64,12 @@ class TestCollectionVersionViewSet(BaseTestCase):
         )
 
         assert response.status_code == 200
-        self.collection_api.list_versions.assert_called_once_with(
+        self.versions_api.list.assert_called_once_with(
             prefix=API_PREFIX, namespace="ansible", name="nginx", limit=10, offset=0
         )
 
     def test_list_limit_offset(self):
-        self.collection_api.list_versions.return_value = galaxy_pulp.ResultsPage(
+        self.versions_api.list.return_value = galaxy_pulp.ResultsPage(
             count=1, results=[]
         )
         response = self.client.get(
@@ -78,18 +78,18 @@ class TestCollectionVersionViewSet(BaseTestCase):
         )
 
         assert response.status_code == 200
-        self.collection_api.list_versions.assert_called_once_with(
+        self.versions_api.list.assert_called_once_with(
             prefix=API_PREFIX, namespace="ansible", name="nginx", limit=10, offset=20
         )
 
     def test_retrieve(self):
-        self.collection_api.get_version.return_value = {}
+        self.versions_api.get.return_value = {}
         response = self.client.get(
             f"/{API_PREFIX}/v3/collections/ansible/nginx/versions/1.2.3/"
         )
 
         assert response.status_code == 200
-        self.collection_api.get_version.assert_called_once_with(
+        self.versions_api.get.assert_called_once_with(
             prefix=API_PREFIX, namespace="ansible", name="nginx", version="1.2.3"
         )
 
@@ -98,7 +98,7 @@ class TestCollectionImportViewSet(BaseTestCase):
     def setUp(self):
         super().setUp()
 
-        patcher = mock.patch("galaxy_pulp.GalaxyImportsApi")
+        patcher = mock.patch("galaxy_pulp.GalaxyImportsApi", spec=True)
         self.imports_api = patcher.start().return_value
         self.addCleanup(patcher.stop)
 


### PR DESCRIPTION
* Add new UI endpoint to set \ unset certified attribute at the
  collection version.
* Split GalaxyCollectionsApi pulp client into two classes:
  - GalaxyCollectionsApi
  - GalaxyCollectionVersionsApi
* Fixed pulp client mocks not checking presense of mocked method
  by building spec for mocks (`spec=True`).

Fixes: ansible/galaxy-dev#73