### PR TITLE
Make the 'v3' api path relative to root prefix

### DIFF
--- a/galaxy_api/api/views.py
+++ b/galaxy_api/api/views.py
@@ -7,9 +7,10 @@ from rest_framework.reverse import reverse
 
 class ApiRootView(views.APIView):
     def get(self, request):
-        root_url = reverse("api:root")
+        # root_url = reverse("api:root")
         data = {
-            "available_versions": {"v3": f"{root_url}v3/"},
+            # "available_versions": {"v3": f"{root_url}v3/"},
+            "available_versions": {"v3": f"v3/"},
         }
         return Response(data)
 

--- a/galaxy_api/api/views.py
+++ b/galaxy_api/api/views.py
@@ -2,6 +2,7 @@ from django.http import HttpResponseRedirect
 
 from rest_framework import views
 from rest_framework.response import Response
+from rest_framework.reverse import reverse
 
 
 class ApiRootView(views.APIView):

--- a/galaxy_api/api/views.py
+++ b/galaxy_api/api/views.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 class ApiRootView(views.APIView):
     def get(self, request):
         data = {
-            "available_versions": {"v3": f"v3/"},
+            "available_versions": {"v3": "v3/"},
         }
         return Response(data)
 

--- a/galaxy_api/api/views.py
+++ b/galaxy_api/api/views.py
@@ -2,14 +2,11 @@ from django.http import HttpResponseRedirect
 
 from rest_framework import views
 from rest_framework.response import Response
-from rest_framework.reverse import reverse
 
 
 class ApiRootView(views.APIView):
     def get(self, request):
-        # root_url = reverse("api:root")
         data = {
-            # "available_versions": {"v3": f"{root_url}v3/"},
             "available_versions": {"v3": f"v3/"},
         }
         return Response(data)

--- a/tests/api/test_api_views.py
+++ b/tests/api/test_api_views.py
@@ -7,5 +7,5 @@ class TestApiRootView(BaseTestCase):
 
         assert response.status_code == 200
         assert response.data == {
-            "available_versions": {"v3": f"/{API_PREFIX}/v3/"},
+            "available_versions": {"v3": "/v3/"},
         }

--- a/tests/api/test_api_views.py
+++ b/tests/api/test_api_views.py
@@ -7,5 +7,5 @@ class TestApiRootView(BaseTestCase):
 
         assert response.status_code == 200
         assert response.data == {
-            "available_versions": {"v3": "/v3/"},
+            "available_versions": {"v3": "v3/"},
         }


### PR DESCRIPTION
ie, available_versions on GET /api/automation-hub/
is {'v3': 'v3/'} instead of {'v3': '/api/automation-hub/v3'}
so ansible-galaxy can use it as a relative path to it's
configured server url.

For ex ansible.cfg:

[galaxy_server.local_hub]
url=http://localhost:5001/api/automation-hub/

ansible-galaxy will have to check '/' for api root
now, and use the value of available_versions to
find the right api path.