### PR TITLE
Let namespace/keywords query params to _ui/collections get passed to pulp

### DIFF
--- a/bindings/openapi.yaml
+++ b/bindings/openapi.yaml
@@ -42,6 +42,10 @@ paths:
           name: q
           schema:
             type: string
+        - in: query
+          name: version
+          schema:
+            type: string
       responses:
         200:
           description: 'OK'

--- a/bindings/openapi.yaml
+++ b/bindings/openapi.yaml
@@ -38,6 +38,10 @@ paths:
           name: limit
           schema:
             type: integer
+        - in: query
+          name: q
+          schema:
+            type: string
       responses:
         200:
           description: 'OK'

--- a/galaxy_api/api/ui/viewsets/collection.py
+++ b/galaxy_api/api/ui/viewsets/collection.py
@@ -39,11 +39,14 @@ class CollectionViewSet(viewsets.GenericViewSet):
         for param_tuple in param_tuples:
             param_key, param_values = param_tuple
 
+            # space separate values if a list
+            param_value = ' '.join(param_values)
+
             # use 'q' instead of 'keywords' for now
             if param_key == 'keywords':
-                param_kwargs['q'] = ' '.join(param_values)
-            else:
-                param_kwargs[param_key] = param_values
+                param_key = 'q'
+
+            param_kwargs[param_key] = param_value
 
         for param_key in param_kwargs:
             log.debug('Final param_kwarg: %s=%s', param_key, param_kwargs[param_key])

--- a/galaxy_api/api/ui/viewsets/collection.py
+++ b/galaxy_api/api/ui/viewsets/collection.py
@@ -1,3 +1,5 @@
+import logging
+
 import galaxy_pulp
 from django.conf import settings
 from rest_framework import viewsets
@@ -10,15 +12,22 @@ from galaxy_api.api import models
 from galaxy_api.api.ui import serializers
 from galaxy_api.common import pulp
 
+log = logging.getLogger(__name__)
 
 class CollectionViewSet(viewsets.GenericViewSet):
     lookup_url_kwarg = 'collection'
     lookup_value_regex = r'[0-9a-z_]+/[0-9a-z_]+'
 
+    QUERY_PARAMS = ['keywords', 'sort', 'tags', 'namespace']
+
     def list(self, request, *args, **kwargs):
         self.paginator.init_from_request(request)
 
         params = self.request.query_params.dict()
+
+        log.debug('query params: %s', params)
+        log.debug('query param .lists(): %s', list(self.request.query_params.lists()))
+        
         params.update({
             'offset': self.paginator.offset,
             'limit': self.paginator.limit,

--- a/galaxy_api/api/ui/viewsets/collection.py
+++ b/galaxy_api/api/ui/viewsets/collection.py
@@ -41,11 +41,9 @@ class CollectionViewSet(viewsets.GenericViewSet):
 
             # use 'q' instead of 'keywords' for now
             if param_key == 'keywords':
-                param_key = 'q'
-
-            for param_value in param_values:
-                # FIXME: only uses the last param value
-                param_kwargs[param_key] = param_value
+                param_kwargs['q'] = ' '.join(param_values)
+            else:
+                param_kwargs[param_key] = param_values
 
         for param_key in param_kwargs:
             log.debug('Final param_kwarg: %s=%s', param_key, param_kwargs[param_key])


### PR DESCRIPTION
Parts of https://github.com/ansible/galaxy-dev/issues/87

namespace: get all the collections that match the EXACT namespace name given.
keywords: search collections

Note: currently, requests like `http://127.0.0.1:5001/api/automation-hub/v3/_ui/collections/?keywords=inspect;keywords=collection` still end up only using the last 'keywords' query param in the pulp request since the galaxy_pulp API bindings squash them in kwargs dict. Investigating how to fix that.