### PR TITLE
Serve static files from django application

### DIFF
--- a/galaxy_api/urls.py
+++ b/galaxy_api/urls.py
@@ -2,6 +2,7 @@
 
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path
 
 
@@ -11,3 +12,5 @@ urlpatterns = [
 
     path('admin/', admin.site.urls),
 ]
+
+urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
This is temporary fix that allows serving static files
for admin site.