### PR TITLE
pulp_ansible collection endpoint s/collections/collection_versions

### DIFF
--- a/bindings/openapi.yaml
+++ b/bindings/openapi.yaml
@@ -7,7 +7,7 @@ info:
 
 paths:
   # Pulp Collections API
-  "/pulp/api/v3/content/ansible/collections/":
+  "/pulp/api/v3/content/ansible/collection_versions/":
     get:
       operationId: "list"
       tags: ["pulp: collections"]
@@ -46,7 +46,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ResultsPage'
 
-  "/pulp/api/v3/content/ansible/collections/{id}/":
+  "/pulp/api/v3/content/ansible/collection_versions/{id}/":
     parameters:
       - in: path
         name: id


### PR DESCRIPTION
pulp_ansible commit 163f2eaa4792e7885329da94b40aba8d44406a8a
to fix 163f2eaa4792e7885329da94b40aba8d44406a8a changed
the endpoint url for content collection versions from

/pulp/api/v3/content/ansible/collections/
to
/pulp/api/v3/content/ansible/collection_versions/