### PR TITLE
Handle ansible-galaxy always appending '/api' to urls

### DIFF
--- a/galaxy_api/api/urls.py
+++ b/galaxy_api/api/urls.py
@@ -11,4 +11,16 @@ urlpatterns = [
     path("", views.ApiRootView.as_view(), name="root"),
     path("v3/", include(v3_urls, namespace="v3"), name="v3_root"),
     path("v3/_ui/", include(ui_urls, namespace="ui")),
+
+    # This path is to redirect requests to /api/automation-hub/api/
+    # to /api/automation-hub/
+
+    # This is a workaround for https://github.com/ansible/ansible/issues/62073.
+    # ansible-galaxy in ansible 2.9 always appends '/api' to any configured
+    # galaxy server urls to try to find the API root. So add a redirect from
+    # "/api" to actual API root at "/".
+
+    # This can be removed when ansible-galaxy stops appending '/api' to the
+    # urls.
+    path("api/", views.SlashApiRedirectView.as_view(), name="compat_redirect"),
 ]

--- a/galaxy_api/api/views.py
+++ b/galaxy_api/api/views.py
@@ -1,3 +1,5 @@
+from django.http import HttpResponseRedirect
+
 from rest_framework import views
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
@@ -10,3 +12,13 @@ class ApiRootView(views.APIView):
             "available_versions": {"v3": f"{root_url}v3/"},
         }
         return Response(data)
+
+
+class SlashApiRedirectView(views.APIView):
+    '''Redirect requests to /api/automation-hub/api/ to /api/automation-hub/
+
+    This is a workaround for https://github.com/ansible/ansible/issues/62073.
+    This can be removed when ansible-galaxy stops appending '/api' to the url.'''
+
+    def get(self, request):
+        return HttpResponseRedirect(reverse('api:root'))


### PR DESCRIPTION
Since ansible-galaxy appends a '/api' to the end of
any configured galaxy url, if 'cloud.redhat.com/api/automation-hub/'
is the configured url, ansible-galaxy tries
'cloud.redhat.com/api/automation-hub/api/'.

So add a redirect from /api/automation-hub/api/ to
/api/automation-hub/