### PR TITLE
Add namespace query params (keywords,name, company) and 'sort' param

### DIFF
--- a/galaxy_api/api/ui/viewsets/namespace.py
+++ b/galaxy_api/api/ui/viewsets/namespace.py
@@ -1,9 +1,37 @@
+from django_filters import filters
+from django_filters.rest_framework import filterset, DjangoFilterBackend
+
 from rest_framework import mixins
 from rest_framework import viewsets
 from rest_framework.settings import api_settings
 
 from galaxy_api.api import models, permissions
 from galaxy_api.api.ui import serializers
+
+
+class NamespaceFilter(filterset.FilterSet):
+    keywords = filters.CharFilter(method='keywords_filter')
+
+    sort = filters.OrderingFilter(
+        fields=(
+            ('name', 'name'),
+            ('company', 'company'),
+            ('id', 'id'),
+        ),
+    )
+
+    class Meta:
+        model = models.Namespace
+        fields = ('name', 'company',)
+
+    def keywords_filter(self, queryset, name, value):
+
+        keywords = self.request.query_params.getlist('keywords')
+
+        for keyword in keywords:
+            queryset = queryset.filter(name=keyword)
+
+        return queryset
 
 
 class NamespaceViewSet(
@@ -18,3 +46,6 @@ class NamespaceViewSet(
     permission_classes = api_settings.DEFAULT_PERMISSION_CLASSES + [
         permissions.IsNamespaceOwnerOrReadOnly
     ]
+    filter_backends = (DjangoFilterBackend,)
+
+    filterset_class = NamespaceFilter


### PR DESCRIPTION
…es/86

Implement
- 'name=namespace_name' that filters against namespace name
- 'company=company_name' that filters against namespace company
- 'keywords=foo' that filters against namespace name
- 'sort=name' / 'sort=-name' to order results.
  Other sort fields are 'company' and 'id'

Fixes: ansible/galaxy-dev#86