### PR TITLE
Fix malformed download responses for dev installs

### DIFF
--- a/galaxy_api/api/v3/viewsets.py
+++ b/galaxy_api/api/v3/viewsets.py
@@ -183,7 +183,7 @@ class CollectionArtifactDownloadView(views.APIView):
 
         if response.status_code == requests.codes.ok:
             return StreamingHttpResponse(
-                response.iter_content(),
+                response.iter_content(chunk_size=None),
                 content_type=response.headers['Content-Type']
             )
 

--- a/galaxy_api/api/v3/viewsets.py
+++ b/galaxy_api/api/v3/viewsets.py
@@ -183,7 +183,7 @@ class CollectionArtifactDownloadView(views.APIView):
 
         if response.status_code == requests.codes.ok:
             return StreamingHttpResponse(
-                response.content,
+                response.iter_content(),
                 content_type=response.headers['Content-Type']
             )
 

--- a/galaxy_api/api/v3/viewsets.py
+++ b/galaxy_api/api/v3/viewsets.py
@@ -183,7 +183,7 @@ class CollectionArtifactDownloadView(views.APIView):
 
         if response.status_code == requests.codes.ok:
             return StreamingHttpResponse(
-                response.iter_content(chunk_size=None),
+                response.iter_content(chunk_size=4096),
                 content_type=response.headers['Content-Type']
             )
 


### PR DESCRIPTION
The StreamingHttpResponse() needs an iterable, so
use Requests response.iter_content(). Using
response.content directly doesn't work.

Fixes: ansible/galaxy-dev#117

After the change, `ansible-galaxy collection install` to a local galaxy/ah will work.

Direct http examples after change:

```
(ansible-py3) [newswoop:F29:ansible (devel % u=)]$ http --verbose --download http://localhost:5001/api/automation-hub/v3/artifacts/collections/alikins.collection_ntp.0.1.182
GET /api/automation-hub/v3/artifacts/collections/alikins.collection_ntp.0.1.182 HTTP/1.1
Accept: */*
Accept-Encoding: identity
Connection: keep-alive
Host: localhost:5001
User-Agent: HTTPie/0.9.9



HTTP/1.1 200 OK
Allow: GET, HEAD, OPTIONS
Connection: close
Content-Type: application/octet-stream
Date: Thu, 19 Sep 2019 18:48:59 GMT
Server: WSGIServer/0.2 CPython/3.6.8
Vary: Accept
X-Frame-Options: SAMEORIGIN

Downloading to "alikins.collection_ntp.0.1.182-7"
Done. 8.01 kB in 0.29746s (26.93 kB/s)
```

```
$ file alikins.collection_ntp.0.1.182-7
alikins.collection_ntp.0.1.182-7: gzip compressed data, was "alikins-collection_ntp-0.1.182.tar", last modified: Tue May 14 17:13:11 2019, max compression, original size 61440
```

```
$ tar tvfl alikins.collection_ntp.0.1.182-7
tar: Removing leading `/' from member names
drwxrwxr-x adrian/adrian     0 2019-05-08 12:14 /
drwxrwxr-x adrian/adrian     0 2019-04-02 10:41 roles/
-rw-rw-r-- adrian/adrian   168 2019-04-18 13:51 =345.43.432
-rw-rw-r-- adrian/adrian    21 2019-04-02 12:39 README.md
-rw-rw-r-- adrian/adrian  1080 2019-04-02 10:45 LICENSE
-rw-rw-r-- adrian/adrian   294 2019-05-14 13:13 galaxy.yml
...
```