### PR TITLE
 Add sso auth info to APIRootView (galaxy-dev#96)

### DIFF
--- a/galaxy_api/api/views.py
+++ b/galaxy_api/api/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.http import HttpResponseRedirect
 
 from rest_framework import views
@@ -9,6 +10,7 @@ class ApiRootView(views.APIView):
     def get(self, request):
         data = {
             "available_versions": {"v3": "v3/"},
+            "token_refresh": {"url": settings.TOKEN_REFRESH_URL}
         }
         return Response(data)
 

--- a/galaxy_api/settings.py
+++ b/galaxy_api/settings.py
@@ -134,7 +134,8 @@ PULP_CONTENT_HOST = 'pulp-content-app'
 PULP_CONTENT_PORT = 24816
 PULP_CONTENT_PATH_PREFIX = '/api/automation-hub/v3/artifacts/collections/'
 
-TOKEN_REFRESH_URL = 'https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token'
+TOKEN_REFRESH_URL = \
+    'https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token'
 
 ################################################################################
 #                                   FOOTER                                     #

--- a/galaxy_api/settings.py
+++ b/galaxy_api/settings.py
@@ -134,6 +134,8 @@ PULP_CONTENT_HOST = 'pulp-content-app'
 PULP_CONTENT_PORT = 24816
 PULP_CONTENT_PATH_PREFIX = '/api/automation-hub/v3/artifacts/collections/'
 
+TOKEN_REFRESH_URL = 'https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token'
+
 ################################################################################
 #                                   FOOTER                                     #
 ################################################################################

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -76,8 +76,36 @@ info:
     ```
 
 
-
 paths:
+  '/':
+    get:
+      summary: API Introspection
+      operationId: getRootApi
+      tags:
+        - API
+      responses:
+        '200':
+          $ref: '#/components/responses/APIRoot'
+        'default':
+          $ref: '#/components/responses/Errors'
+
+  '/api/':
+    get:
+      summary: Redirect to API Introspection
+      operationId: getRootApiRedirect
+      tags:
+        - API
+      responses:
+        '302':
+          description: 'Redirect to API Introspection'
+          headers:
+            Location:
+              schema:
+                type: string
+                format: uri
+                example: '/'
+        'default':
+          $ref: '#/components/responses/Errors'
 
 # -------------------------------------
 # Collections
@@ -467,6 +495,34 @@ paths:
 
 components:
   schemas:
+    APIRoot:
+      title: 'API'
+      description: 'API root introspection'
+      type: object
+      properties:
+        available_versions:
+          description: 'The available API versions and their URLS'
+          type: object
+          readOnly: true
+          additionalProperties:
+            type: string
+          example:
+            v2: 'v2/'
+            v3: 'v3/'
+        token_refresh:
+          description: 'Info about where and how to refresh authentication tokens'
+          type: object
+          readOnly: True
+          properties:
+            url:
+              description: 'The URL to POST to to get a session token'
+              type: string
+              format: uri
+              example: 'https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token'
+      required:
+        - available_versions
+        - token_refresh
+
     Author:
       description: 'Author of a collection or role'
       type: string
@@ -1605,6 +1661,12 @@ components:
             $ref: '#/components/schemas/Namespace'
 
   responses:
+    APIRoot:
+      description: 'Response containing an APIRoot'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/APIRoot'
 
     Collection:
       description: 'Response containing a Collection'

--- a/tests/api/test_api_views.py
+++ b/tests/api/test_api_views.py
@@ -1,3 +1,6 @@
+
+from django.conf import settings
+
 from .base import BaseTestCase, API_PREFIX
 
 
@@ -6,6 +9,8 @@ class TestApiRootView(BaseTestCase):
         response = self.client.get(f"/{API_PREFIX}/")
 
         assert response.status_code == 200
-        assert response.data == {
-            "available_versions": {"v3": "v3/"},
-        }
+        assert response.data['available_versions'] == {"v3": "v3/"}
+
+        assert response.data['token_refresh'] == \
+            {'url':
+             settings.TOKEN_REFRESH_URL}


### PR DESCRIPTION
Note there is a potential catch-22 here if 'GET /api/automation-hub' requires authentication: You would need to authenticate before you can get the info where you should authenticate.