### PR TITLE
Return 307 for ApiRootView for ansible-galaxy

### DIFF
--- a/galaxy_api/api/urls.py
+++ b/galaxy_api/api/urls.py
@@ -23,4 +23,5 @@ urlpatterns = [
     # This can be removed when ansible-galaxy stops appending '/api' to the
     # urls.
     path("api/", views.SlashApiRedirectView.as_view(), name="compat_redirect"),
+    path("api", views.SlashApiRedirectView.as_view(), name="compat_redirect"),
 ]

--- a/galaxy_api/api/views.py
+++ b/galaxy_api/api/views.py
@@ -1,11 +1,14 @@
 from django.http import HttpResponseRedirect
 
 from rest_framework import views
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
 
 class ApiRootView(views.APIView):
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
     def get(self, request):
         data = {
             "available_versions": {"v3": "v3/"},
@@ -19,5 +22,7 @@ class SlashApiRedirectView(views.APIView):
     This is a workaround for https://github.com/ansible/ansible/issues/62073.
     This can be removed when ansible-galaxy stops appending '/api' to the url.'''
 
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
     def get(self, request):
-        return HttpResponseRedirect(reverse('api:root'))
+        return HttpResponseRedirect(reverse('api:root'), status=307)


### PR DESCRIPTION
If ansible-galaxy gets a 301 or 302 redirect from
a server, when it follows the new Location, it does
not include any authentication info.

Since ansible-galaxy also always appends '/api'
which lacks a trailing '/', there is always at
least one redirect plus the redirect from
$real_url/api -> $real_url.

Which means requests to / to get the ApiRootView
with the available versions and auth url info,
ansible-galaxy doesn't send auth.

But if the redirect is a 307 or 308, it will follow.
So make the $real_url/api -> $real_url redirect a
307. Otherwise ansible-galaxy doesn't work against
Automation Hub.