### PR TITLE
Make an empty /collections/{ns}/{n} a 404

### DIFF
--- a/galaxy_api/api/v3/viewsets.py
+++ b/galaxy_api/api/v3/viewsets.py
@@ -73,6 +73,11 @@ class CollectionVersionViewSet(viewsets.GenericViewSet):
             name=self.kwargs['name'],
             **params,
         )
+
+        # Consider an empty list of versions as a 404 on the Collection
+        if not response.results:
+            raise NotFound()
+
         return self.paginator.paginate_proxy_response(response.results, response.count)
 
     def retrieve(self, request, *args, **kwargs):

--- a/tests/api/test_api_v3_viewsets.py
+++ b/tests/api/test_api_v3_viewsets.py
@@ -55,9 +55,22 @@ class TestCollectionVersionViewSet(BaseTestCase):
         self.versions_api = patcher.start().return_value
         self.addCleanup(patcher.stop)
 
-    def test_list(self):
+    def test_list_empty(self):
         self.versions_api.list.return_value = galaxy_pulp.ResultsPage(
             count=1, results=[]
+        )
+        response = self.client.get(
+            f"/{API_PREFIX}/v3/collections/ansible/nginx/versions/"
+        )
+
+        assert response.status_code == 404
+        self.versions_api.list.assert_called_once_with(
+            prefix=API_PREFIX, namespace="ansible", name="nginx", limit=10, offset=0
+        )
+
+    def test_list(self):
+        self.versions_api.list.return_value = galaxy_pulp.ResultsPage(
+            count=1, results=[{}]
         )
         response = self.client.get(
             f"/{API_PREFIX}/v3/collections/ansible/nginx/versions/"
@@ -70,7 +83,7 @@ class TestCollectionVersionViewSet(BaseTestCase):
 
     def test_list_limit_offset(self):
         self.versions_api.list.return_value = galaxy_pulp.ResultsPage(
-            count=1, results=[]
+            count=1, results=[{}]
         )
         response = self.client.get(
             f"/{API_PREFIX}/v3/collections/ansible/nginx/versions/",
@@ -78,6 +91,20 @@ class TestCollectionVersionViewSet(BaseTestCase):
         )
 
         assert response.status_code == 200
+        self.versions_api.list.assert_called_once_with(
+            prefix=API_PREFIX, namespace="ansible", name="nginx", limit=10, offset=20
+        )
+
+    def test_list_limit_offset_empty(self):
+        self.versions_api.list.return_value = galaxy_pulp.ResultsPage(
+            count=1, results=[]
+        )
+        response = self.client.get(
+            f"/{API_PREFIX}/v3/collections/ansible/nginx/versions/",
+            data={"limit": 10, "offset": 20},
+        )
+
+        assert response.status_code == 404
         self.versions_api.list.assert_called_once_with(
             prefix=API_PREFIX, namespace="ansible", name="nginx", limit=10, offset=20
         )


### PR DESCRIPTION
This is related to https://github.com/ansible/ansible/issues/63210

If pulp returned an empty list for a collection version, galaxy-api
CollectionVersionViewset() would return a 200 and an empty list.
Pulp may return an empty list if the collection doesn't exist.

ansible-galaxy expects a 404 to be returned if the collection
doesn't exist.