### PR TITLE
Fix auth connecting to pulp api.

### DIFF
--- a/galaxy_api/api/v3/viewsets.py
+++ b/galaxy_api/api/v3/viewsets.py
@@ -127,8 +127,7 @@ class CollectionArtifactUploadView(views.APIView):
         api = pulp.get_client()
         url = '{host}/{prefix}{path}'.format(
             host=api.configuration.host,
-            prefix=settings.API_PATH_PREFIX,
-            path='/v3/artifacts/collections/',
+            path='ansible/collections/',
         )
 
         post_params = self._prepare_post_params(data)

--- a/galaxy_api/api/v3/viewsets.py
+++ b/galaxy_api/api/v3/viewsets.py
@@ -129,13 +129,18 @@ class CollectionArtifactUploadView(views.APIView):
             host=api.configuration.host,
             path='ansible/collections/',
         )
+        headers = {}
+        headers.update(api.default_headers)
+        headers.update({'Content-Type': 'multipart/form-data'})
+
+        api.update_params_for_auth(headers, tuple(), api.configuration.auth_settings())
 
         post_params = self._prepare_post_params(data)
         try:
             upload_response = api.request(
                 'POST',
                 url,
-                headers={'Content-Type': 'multipart/form-data'},
+                headers=headers,
                 post_params=post_params,
             )
         except galaxy_pulp.ApiException:


### PR DESCRIPTION
galaxy_pup.api_client.APIClient.request()
doesn't set auth headers the same way
other higher level calls do. So make sure
it sets the auth headers.

Otherwise the basic auth connection to pulp_ansible fails on publish