### PR TITLE
Fix galaxy_pulp CollectionImport json-ify error

### DIFF
--- a/galaxy_api/api/v3/viewsets.py
+++ b/galaxy_api/api/v3/viewsets.py
@@ -97,7 +97,8 @@ class CollectionImportViewSet(viewsets.ViewSet):
     def retrieve(self, request, pk):
         api = galaxy_pulp.GalaxyImportsApi(pulp.get_client())
         response = api.get(prefix=settings.API_PATH_PREFIX, id=pk)
-        return Response(response)
+
+        return Response(data=response.to_dict())
 
 
 class CollectionArtifactUploadView(views.APIView):


### PR DESCRIPTION
The response returned from galaxy_pulp.GalaxyImportsApi.get()
is a galaxy_pulp.models.collection_import.CollectionImport,
which somehow is not JSON serializable as is.

So use it's to_dict() method to get a dictionary that
is serializable.

It's not clear to me why it isn't JSON serializable yet.  The model
seems to follow similar approach as other galaxy_pulp.models.
And galaxy_pulp.api.ApiClient.sanitize_for_serialization() seems
to try to make it serializable.

Not sure yet if similar issues will apply to other galaxy_pulp models.

But this fixes issues with getting task details through the v3 galaxy api
as shown at https://gist.github.com/alikins/690301d61ab84dcbee66f78b172d23b1

```
galaxy-api_1             | ERROR 2019-10-15 19:54:00,325 django.server basehttp:log_message:154 24 140188519290624 "GET /api/automation-hub/v3/imports/collections/2bff928f-49f5-477c-80ca-76c89adbf4c4/ HTTP/1.1" 500 149001
galaxy-api_1             | ERROR 2019-10-15 19:54:21,166 django.request log:log_response:228 24 140188519290624 Internal Server Error: /api/automation-hub/v3/imports/collections/2bff928f-49f5-477c-80ca-76c89adbf4c4/
galaxy-api_1             | Traceback (most recent call last):
galaxy-api_1             |   File "/venv/lib64/python3.6/site-packages/django/core/handlers/exception.py", line 34, in inner
galaxy-api_1             |     response = get_response(request)
galaxy-api_1             |   File "/venv/lib64/python3.6/site-packages/django/core/handlers/base.py", line 145, in _get_response
galaxy-api_1             |     response = self.process_exception_by_middleware(e, request)
galaxy-api_1             |   File "/venv/lib64/python3.6/site-packages/django/core/handlers/base.py", line 143, in _get_response
galaxy-api_1             |     response = response.render()
galaxy-api_1             |   File "/venv/lib64/python3.6/site-packages/django/template/response.py", line 106, in render
galaxy-api_1             |     self.content = self.rendered_content
galaxy-api_1             |   File "/venv/lib64/python3.6/site-packages/rest_framework/response.py", line 70, in rendered_content
galaxy-api_1             |     ret = renderer.render(self.data, accepted_media_type, context)
galaxy-api_1             |   File "/venv/lib64/python3.6/site-packages/rest_framework/renderers.py", line 104, in render
galaxy-api_1             |     allow_nan=not self.strict, separators=separators
galaxy-api_1             |   File "/venv/lib64/python3.6/site-packages/rest_framework/utils/json.py", line 25, in dumps
galaxy-api_1             |     return json.dumps(*args, **kwargs)
galaxy-api_1             |   File "/usr/lib64/python3.6/json/__init__.py", line 238, in dumps
galaxy-api_1             |     **kw).encode(obj)
galaxy-api_1             |   File "/usr/lib64/python3.6/json/encoder.py", line 199, in encode
galaxy-api_1             |     chunks = self.iterencode(o, _one_shot=True)
galaxy-api_1             |   File "/usr/lib64/python3.6/json/encoder.py", line 257, in iterencode
galaxy-api_1             |     return _iterencode(o, 0)
galaxy-api_1             |   File "/venv/lib64/python3.6/site-packages/rest_framework/utils/encoders.py", line 67, in default
galaxy-api_1             |     return super().default(obj)
galaxy-api_1             |   File "/usr/lib64/python3.6/json/encoder.py", line 180, in default
galaxy-api_1             |     o.__class__.__name__)
galaxy-api_1             | TypeError: Object of type 'CollectionImport' is not JSON serializable

```