### PR TITLE
Make collection deprecated update-able #129

### DIFF
--- a/bindings/openapi.yaml
+++ b/bindings/openapi.yaml
@@ -162,6 +162,21 @@ paths:
             application/json:
               schema:
                 type: object
+    put:
+      operationId: "put"
+      tags: ["galaxy: collections"]
+      requestBody:
+        content:
+          appication/json:
+            schema:
+              $ref: '#/components/schemas/Collection'
+      responses:
+        200:
+          description: 'OK'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Collection'
 
   # Galaxy Collection Versions API
   "/{prefix}/v3/collections/{namespace}/{name}/versions/":
@@ -367,6 +382,16 @@ components:
           type: array
           items:
             type: object
+
+    Collection:
+      type: object
+      properties:
+        name:
+          type: string
+        namespace:
+          type: string
+        deprecated:
+          type: boolean
 
     CollectionImport:
       type: object

--- a/bindings/openapi.yaml
+++ b/bindings/openapi.yaml
@@ -167,7 +167,7 @@ paths:
       tags: ["galaxy: collections"]
       requestBody:
         content:
-          appication/json:
+          application/json:
             schema:
               $ref: '#/components/schemas/Collection'
       responses:

--- a/galaxy_api/api/ui/urls.py
+++ b/galaxy_api/api/ui/urls.py
@@ -3,7 +3,6 @@ from rest_framework import routers
 
 from . import viewsets
 
-
 router = routers.SimpleRouter()
 router.register('namespaces', viewsets.NamespaceViewSet, basename='namespaces')
 router.register('my-namespaces', viewsets.MyNamespaceViewSet, basename='namespaces')

--- a/galaxy_api/api/ui/urls.py
+++ b/galaxy_api/api/ui/urls.py
@@ -3,6 +3,7 @@ from rest_framework import routers
 
 from . import viewsets
 
+
 router = routers.SimpleRouter()
 router.register('namespaces', viewsets.NamespaceViewSet, basename='namespaces')
 router.register('my-namespaces', viewsets.MyNamespaceViewSet, basename='namespaces')

--- a/galaxy_api/api/ui/viewsets/collection.py
+++ b/galaxy_api/api/ui/viewsets/collection.py
@@ -13,6 +13,9 @@ from galaxy_api.api import models, permissions
 from galaxy_api.api.ui import serializers
 from galaxy_api.common import pulp
 
+import logging
+log = logging.getLogger(__name__)
+
 
 class CollectionViewSet(viewsets.GenericViewSet):
     lookup_url_kwarg = 'collection'
@@ -98,8 +101,29 @@ class CollectionViewSet(viewsets.GenericViewSet):
 
         return Response(data)
 
-    def set_deprecated(self):
-        pass
+    def set_deprecated(self, request, *args, **kwargs):
+        namespace, name = self.kwargs['collection'].split('/')
+        # namespace_obj = get_object_or_404(models.Namespace, name=namespace)
+
+        # params_dict = self.request.query_params.dict()
+        log.debug('namespace: %s name: %s', namespace, name)
+
+        api = galaxy_pulp.GalaxyCollectionsApi(pulp.get_client())
+
+        collection = galaxy_pulp.models.Collection(name=name, namespace=namespace, deprecated=True)
+
+        log.debug('collection: %s', collection)
+
+        response = api.get(
+            prefix=settings.API_PATH_PREFIX,
+            namespace=namespace,
+            name=name,
+            collection=collection,
+        )
+
+        log.debug('response: %s', response)
+
+        return Response(response)
 
     @staticmethod
     def _query_namespaces(names):

--- a/galaxy_api/api/ui/viewsets/collection.py
+++ b/galaxy_api/api/ui/viewsets/collection.py
@@ -13,9 +13,6 @@ from galaxy_api.api import models, permissions
 from galaxy_api.api.ui import serializers
 from galaxy_api.common import pulp
 
-import logging
-log = logging.getLogger(__name__)
-
 
 class CollectionViewSet(viewsets.GenericViewSet):
     lookup_url_kwarg = 'collection'
@@ -107,13 +104,9 @@ class CollectionViewSet(viewsets.GenericViewSet):
 
         self.check_object_permissions(request, namespace_obj)
 
-        log.debug('namespace: %s name: %s', namespace, name)
-
         api = galaxy_pulp.GalaxyCollectionsApi(pulp.get_client())
 
         collection = galaxy_pulp.models.Collection(name=name, namespace=namespace, deprecated=True)
-
-        log.debug('collection: %s', collection)
 
         response = api.put(
             prefix=settings.API_PATH_PREFIX,
@@ -121,8 +114,6 @@ class CollectionViewSet(viewsets.GenericViewSet):
             name=name,
             collection=collection,
         )
-
-        log.debug('response: %s', response)
 
         return Response(response)
 

--- a/galaxy_api/api/ui/viewsets/collection.py
+++ b/galaxy_api/api/ui/viewsets/collection.py
@@ -115,7 +115,7 @@ class CollectionViewSet(viewsets.GenericViewSet):
 
         log.debug('collection: %s', collection)
 
-        response = api.get(
+        response = api.put(
             prefix=settings.API_PATH_PREFIX,
             namespace=namespace,
             name=name,

--- a/galaxy_api/api/ui/viewsets/collection.py
+++ b/galaxy_api/api/ui/viewsets/collection.py
@@ -98,25 +98,6 @@ class CollectionViewSet(viewsets.GenericViewSet):
 
         return Response(data)
 
-    def update(self, request, *args, **kwargs):
-        namespace, name = self.kwargs['collection'].split('/')
-        namespace_obj = get_object_or_404(models.Namespace, name=namespace)
-
-        self.check_object_permissions(request, namespace_obj)
-
-        api = galaxy_pulp.GalaxyCollectionsApi(pulp.get_client())
-
-        collection = galaxy_pulp.models.Collection(name=name, namespace=namespace, deprecated=True)
-
-        response = api.put(
-            prefix=settings.API_PATH_PREFIX,
-            namespace=namespace,
-            name=name,
-            collection=collection,
-        )
-
-        return Response(response)
-
     @staticmethod
     def _query_namespaces(names):
         queryset = models.Namespace.objects.filter(name__in=names)

--- a/galaxy_api/api/ui/viewsets/collection.py
+++ b/galaxy_api/api/ui/viewsets/collection.py
@@ -101,11 +101,12 @@ class CollectionViewSet(viewsets.GenericViewSet):
 
         return Response(data)
 
-    def set_deprecated(self, request, *args, **kwargs):
+    def update(self, request, *args, **kwargs):
         namespace, name = self.kwargs['collection'].split('/')
-        # namespace_obj = get_object_or_404(models.Namespace, name=namespace)
+        namespace_obj = get_object_or_404(models.Namespace, name=namespace)
 
-        # params_dict = self.request.query_params.dict()
+        self.check_object_permissions(request, namespace_obj)
+
         log.debug('namespace: %s name: %s', namespace, name)
 
         api = galaxy_pulp.GalaxyCollectionsApi(pulp.get_client())

--- a/galaxy_api/api/v3/serializers.py
+++ b/galaxy_api/api/v3/serializers.py
@@ -9,8 +9,6 @@ class CollectionUpdateSerializer(serializers.Serializer):
     """A serializer for a Collection update."""
 
     deprecated = serializers.BooleanField(required=False)
-    namespace = serializers.CharField(required=True)
-    name = serializers.CharField(required=True)
 
 
 class CollectionUploadSerializer(serializers.Serializer):

--- a/galaxy_api/api/v3/serializers.py
+++ b/galaxy_api/api/v3/serializers.py
@@ -5,8 +5,10 @@ from rest_framework import serializers
 from galaxy_api.api.utils import parse_collection_filename
 
 
-class CollectionUpdateSerializer(serializers.Serializer):
-    """A serializer for a Collection update."""
+class CollectionSerializer(serializers.Serializer):
+
+    name = serializers.CharField(required=True)
+    namespace = serializers.CharField(required=True)
 
     deprecated = serializers.BooleanField(required=False)
 

--- a/galaxy_api/api/v3/serializers.py
+++ b/galaxy_api/api/v3/serializers.py
@@ -5,6 +5,14 @@ from rest_framework import serializers
 from galaxy_api.api.utils import parse_collection_filename
 
 
+class CollectionUpdateSerializer(serializers.Serializer):
+    """A serializer for a Collection update."""
+
+    deprecated = serializers.BooleanField(required=False)
+    namespace = serializers.CharField(required=True)
+    name = serializers.CharField(required=True)
+
+
 class CollectionUploadSerializer(serializers.Serializer):
     """
     A serializer for the Collection One Shot Upload API.

--- a/galaxy_api/api/v3/urls.py
+++ b/galaxy_api/api/v3/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
     ),
     path(
         'collections/<str:namespace>/<str:name>/',
-        viewsets.CollectionViewSet.as_view({'get': 'retrieve'}),
+        viewsets.CollectionViewSet.as_view({'get': 'retrieve', 'put': 'update'}),
     ),
     path(
         'collections/<str:namespace>/<str:name>/versions/',

--- a/galaxy_api/api/v3/viewsets.py
+++ b/galaxy_api/api/v3/viewsets.py
@@ -26,7 +26,7 @@ from rest_framework import viewsets
 from rest_framework.settings import api_settings
 
 from galaxy_api.api.models import Namespace
-from galaxy_api.api.v3.serializers import CollectionUploadSerializer, CollectionUpdateSerializer
+from galaxy_api.api.v3.serializers import CollectionSerializer, CollectionUploadSerializer
 from galaxy_api.common import pulp
 from galaxy_api.api import permissions, models
 
@@ -34,6 +34,8 @@ from galaxy_api.api import permissions, models
 class CollectionViewSet(viewsets.GenericViewSet):
     permission_classes = api_settings.DEFAULT_PERMISSION_CLASSES + \
         [permissions.IsNamespaceOwnerOrPartnerEngineer]
+
+    serializer_class = CollectionSerializer
 
     def list(self, request, *args, **kwargs):
         self.paginator.init_from_request(request)
@@ -50,11 +52,13 @@ class CollectionViewSet(viewsets.GenericViewSet):
 
     def retrieve(self, request, *args, **kwargs):
         api = galaxy_pulp.GalaxyCollectionsApi(pulp.get_client())
+
         response = api.get(
             prefix=settings.API_PATH_PREFIX,
             namespace=self.kwargs['namespace'],
             name=self.kwargs['name']
         )
+
         return Response(response)
 
     def update(self, request, *args, **kwargs):
@@ -64,7 +68,7 @@ class CollectionViewSet(viewsets.GenericViewSet):
         namespace_obj = get_object_or_404(models.Namespace, name=namespace)
         self.check_object_permissions(self.request, namespace_obj)
 
-        serializer = CollectionUpdateSerializer(data=request.data, context={'request': request})
+        serializer = CollectionSerializer(data=request.data, context={'request': request})
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
 

--- a/galaxy_api/api/v3/viewsets.py
+++ b/galaxy_api/api/v3/viewsets.py
@@ -30,9 +30,6 @@ from galaxy_api.api.v3.serializers import CollectionUploadSerializer, Collection
 from galaxy_api.common import pulp
 from galaxy_api.api import permissions, models
 
-import logging
-log = logging.getLogger(__name__)
-
 
 class CollectionViewSet(viewsets.GenericViewSet):
     permission_classes = api_settings.DEFAULT_PERMISSION_CLASSES + \
@@ -61,22 +58,16 @@ class CollectionViewSet(viewsets.GenericViewSet):
         return Response(response)
 
     def update(self, request, *args, **kwargs):
-        log.debug('request.META: %s', request.META)
-        log.debug('request.headers: %s', request.headers)
-        log.debug('update')
         namespace = self.kwargs['namespace']
         name = self.kwargs['name']
 
         namespace_obj = get_object_or_404(models.Namespace, name=namespace)
         self.check_object_permissions(self.request, namespace_obj)
 
-        log.debug('perms okay for user=%s', request.user)
-
         serializer = CollectionUpdateSerializer(data=request.data, context={'request': request})
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
 
-        log.debug('data: %s', data)
         collection = galaxy_pulp.models.Collection(name=name,
                                                    namespace=namespace,
                                                    deprecated=data.get('deprecated', False))

--- a/galaxy_api/api/v3/viewsets.py
+++ b/galaxy_api/api/v3/viewsets.py
@@ -30,6 +30,9 @@ from galaxy_api.api.v3.serializers import CollectionUploadSerializer, Collection
 from galaxy_api.common import pulp
 from galaxy_api.api import permissions, models
 
+import logging
+log = logging.getLogger(__name__)
+
 
 class CollectionViewSet(viewsets.GenericViewSet):
     permission_classes = api_settings.DEFAULT_PERMISSION_CLASSES + \
@@ -58,17 +61,22 @@ class CollectionViewSet(viewsets.GenericViewSet):
         return Response(response)
 
     def update(self, request, *args, **kwargs):
-
+        log.debug('request.META: %s', request.META)
+        log.debug('request.headers: %s', request.headers)
+        log.debug('update')
         namespace = self.kwargs['namespace']
         name = self.kwargs['name']
 
         namespace_obj = get_object_or_404(models.Namespace, name=namespace)
         self.check_object_permissions(self.request, namespace_obj)
 
+        log.debug('perms okay for user=%s', request.user)
+
         serializer = CollectionUpdateSerializer(data=request.data, context={'request': request})
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
 
+        log.debug('data: %s', data)
         collection = galaxy_pulp.models.Collection(name=name,
                                                    namespace=namespace,
                                                    deprecated=data.get('deprecated', False))

--- a/galaxy_api/api/v3/viewsets.py
+++ b/galaxy_api/api/v3/viewsets.py
@@ -68,9 +68,7 @@ class CollectionViewSet(viewsets.GenericViewSet):
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
 
-        collection = galaxy_pulp.models.Collection(name=name,
-                                                   namespace=namespace,
-                                                   deprecated=data.get('deprecated', False))
+        collection = galaxy_pulp.models.Collection(deprecated=data.get('deprecated', False))
 
         api = galaxy_pulp.GalaxyCollectionsApi(pulp.get_client())
 

--- a/galaxy_api/api/v3/viewsets.py
+++ b/galaxy_api/api/v3/viewsets.py
@@ -30,9 +30,6 @@ from galaxy_api.api.v3.serializers import CollectionUploadSerializer, Collection
 from galaxy_api.common import pulp
 from galaxy_api.api import permissions, models
 
-import logging
-log = logging.getLogger(__name__)
-
 
 class CollectionViewSet(viewsets.GenericViewSet):
     permission_classes = api_settings.DEFAULT_PERMISSION_CLASSES + \
@@ -61,29 +58,11 @@ class CollectionViewSet(viewsets.GenericViewSet):
         return Response(response)
 
     def update(self, request, *args, **kwargs):
-        log.debug('update request: %s args:%r kwargs: %r', request, args, kwargs)
-        log.debug('request: %s', request)
-        import pprint
-        log.debug('request.META: %s', pprint.pformat(request.META))
-        log.debug('request.headers: %s', pprint.pformat(request.headers))
-        log.debug('request.body: %s', pprint.pformat(request.body))
-        log.debug('request.accepted_media_type: %s', request.accepted_media_type)
-        log.debug('request.accepted_renderer: %s', request.accepted_renderer)
-        log.debug('request.content_type: %s', request.content_type)
-        log.debug('request.user: %s', request.user)
-        log.debug('request.auth: %s', request.auth)
-        log.debug('request.session: %s', request.session)
-        log.debug('args %r', args)
-        log.debug('kwargs: %r', kwargs)
-        log.debug('self.kwargs: %r', self.kwargs)
 
         namespace = self.kwargs['namespace']
         name = self.kwargs['name']
 
-        log.debug('namespace: %s name: %s', namespace, name)
-
         namespace_obj = get_object_or_404(models.Namespace, name=namespace)
-        log.debug('namespace_obj: %s', namespace_obj)
         self.check_object_permissions(self.request, namespace_obj)
 
         serializer = CollectionUpdateSerializer(data=request.data, context={'request': request})
@@ -94,8 +73,6 @@ class CollectionViewSet(viewsets.GenericViewSet):
                                                    namespace=namespace,
                                                    deprecated=data.get('deprecated', False))
 
-        log.debug('collection: %s', collection)
-
         api = galaxy_pulp.GalaxyCollectionsApi(pulp.get_client())
 
         response = api.put(
@@ -104,9 +81,6 @@ class CollectionViewSet(viewsets.GenericViewSet):
             name=name,
             collection=collection,
         )
-
-        log.debug('response: %s', type(response))
-        log.debug('response: %s', response)
 
         return Response(response.to_dict())
 

--- a/tests/api/test_api_v3_viewsets.py
+++ b/tests/api/test_api_v3_viewsets.py
@@ -1,6 +1,8 @@
 import base64
 from unittest import mock
 
+import pytest
+
 from rest_framework.test import APIClient
 import galaxy_pulp
 
@@ -11,24 +13,29 @@ from .base import BaseTestCase, API_PREFIX
 import logging
 log = logging.getLogger(__name__)
 
-b_test_user_token_json = b"""{
-    "entitlements":
-        {"insights":
-            {"is_entitled": true}
-        },
-    "identity":
-        {"account_number": "12345",
-         "user":
-            {"username": "test",
-             "email": "test@example.invalid",
-             "first_name": "Test",
-             "last_name": "User"
-             },
-         "internal": {"org_id": "54321"}
-         }
-}"""
 
-test_user_token_b64 = base64.b64encode(b_test_user_token_json)
+@pytest.fixture
+def user_x_rh_identity():
+    b_test_user_token_json = b"""{
+        "entitlements":
+            {"insights":
+                {"is_entitled": true}
+            },
+        "identity":
+            {"account_number": "12345",
+            "user":
+                {"username": "test",
+                "email": "test@example.invalid",
+                "first_name": "Test",
+                "last_name": "User"
+                },
+            "internal": {"org_id": "54321"}
+            }
+    }"""
+
+    token_b64 = base64.b64encode(b_test_user_token_json)
+
+    return token_b64
 
 
 class TestCollectionViewSet(BaseTestCase):
@@ -122,6 +129,25 @@ class TestCollectionViewSet(BaseTestCase):
         partner_group = self._create_group('system', 'partner-engineers', users=self.user)
         namespace = self._create_namespace('test', partner_group)
         log.debug('namespace: %s', namespace)
+
+        b_test_user_token_json = b"""{
+            "entitlements":
+                {"insights":
+                    {"is_entitled": true}
+                },
+            "identity":
+                {"account_number": "12345",
+                "user":
+                    {"username": "test",
+                    "email": "test@example.invalid",
+                    "first_name": "Test",
+                    "last_name": "User"
+                    },
+                "internal": {"org_id": "54321"}
+                }
+        }"""
+
+        test_user_token_b64 = base64.b64encode(b_test_user_token_json)
 
         client = APIClient()
         client.credentials(**{"HTTP_X_RH_IDENTITY": test_user_token_b64})


### PR DESCRIPTION
Add `PUT /api/automation-hub/v3/collections/{ns}/{name}/` for updating a Collection (so that 'deprecated' can be updated).

WIP since it needs tests and other cleanup.