### PR TITLE
Fix the reverse() of MyNamespaceViewSet to 'api:my-namespaces'

### DIFF
--- a/galaxy_api/api/ui/urls.py
+++ b/galaxy_api/api/ui/urls.py
@@ -6,7 +6,7 @@ from . import viewsets
 
 router = routers.SimpleRouter()
 router.register('namespaces', viewsets.NamespaceViewSet, basename='namespaces')
-router.register('my-namespaces', viewsets.MyNamespaceViewSet, basename='namespaces')
+router.register('my-namespaces', viewsets.MyNamespaceViewSet, basename='my-namespaces')
 router.register('collections', viewsets.CollectionViewSet, basename='collections')
 router.register(
     'collections/(?P<collection>{})/versions'.format(


### PR DESCRIPTION
Both NamespaceViewSet and MyNamespaceViewSet were registered to
the url reverse of 'api:ui:namespaces-list' since they both
registered to the router with basename='namespaces'.