### PR TITLE
Enable yamllint and make the repo yamllintable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 language: python
 python: '3.6'
 services:
@@ -16,8 +17,9 @@ install:
 
 jobs:
   include:
-    - name: "Flake8"
-      script: tox -e flake8
+    - name: "Linters"
+      script: tox -e linters
+
     - name: "Unit tests"
       script: tox -e py36
       services:

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,14 @@
+---
+extends: default
+
+ignore: |
+  .tox
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  line-length: disable

--- a/bindings/openapi.yaml
+++ b/bindings/openapi.yaml
@@ -1,3 +1,4 @@
+---
 openapi: "3.0.0"
 info:
   version: "1.0.0"

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,3 +1,4 @@
+---
 openapi: "3.0.0"
 
 info:
@@ -76,12 +77,11 @@ info:
     ```
 
 
-
 paths:
 
-# -------------------------------------
-# Collections
-# -------------------------------------
+  # -------------------------------------
+  # Collections
+  # -------------------------------------
 
   '/collections/':
     get:
@@ -115,7 +115,7 @@ paths:
         '200':
           $ref: '#/components/responses/Collection'
         'default':
-            $ref: '#/components/responses/Errors'
+          $ref: '#/components/responses/Errors'
 
   '/collections/{namespace}/{name}/versions/':
     parameters:
@@ -156,9 +156,9 @@ paths:
         'default':
           $ref: '#/components/responses/Errors'
 
-# -------------------------------------
-# Artifacts
-# -------------------------------------
+  # -------------------------------------
+  # Artifacts
+  # -------------------------------------
 
   '/artifacts/collections/':
     post:
@@ -216,9 +216,9 @@ paths:
         'default':
           $ref: '#/components/responses/Errors'
 
-# -------------------------------------
-# Imports
-# -------------------------------------
+  # -------------------------------------
+  # Imports
+  # -------------------------------------
 
   '/imports/collections/{import_id}/':
     get:
@@ -403,9 +403,9 @@ components:
           required:
             - data
 
-# -------------------------------------
-# Schemas: Collection
-# -------------------------------------
+    # -------------------------------------
+    # Schemas: Collection
+    # -------------------------------------
 
     CollectionVersion:
       type: object
@@ -608,9 +608,9 @@ components:
           required:
             - data
 
-# -------------------------------------
-# Schemas: Errors
-# -------------------------------------
+    # -------------------------------------
+    # Schemas: Errors
+    # -------------------------------------
 
     Errors:
       title: 'Errors'
@@ -672,9 +672,9 @@ components:
         - detail
         - status
 
-# -------------------------------------
-# Schemas: Namespaces
-# -------------------------------------
+    # -------------------------------------
+    # Schemas: Namespaces
+    # -------------------------------------
 
     Namespace:
       title: 'Namespace'
@@ -767,9 +767,9 @@ components:
           type: string
           format: uri
 
-# -------------------------------------
-# Schemas: Pagination
-# -------------------------------------
+    # -------------------------------------
+    # Schemas: Pagination
+    # -------------------------------------
 
     PageInfo:
       description: 'Pagination info'
@@ -1077,4 +1077,3 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Errors'
-

--- a/openapi/ui_openapi.yaml
+++ b/openapi/ui_openapi.yaml
@@ -1,3 +1,4 @@
+---
 openapi: "3.0.0"
 
 info:
@@ -82,9 +83,9 @@ info:
 
 paths:
 
-# -------------------------------------
-# UI: Collections
-# -------------------------------------
+  # -------------------------------------
+  # UI: Collections
+  # -------------------------------------
 
   '/_ui/collections/':
     get:
@@ -129,7 +130,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/CollectionUi'
         'default':
-            $ref: '#/components/responses/Errors'
+          $ref: '#/components/responses/Errors'
 
   '/_ui/collections/{namespace}/{name}/versions/':
     parameters:
@@ -170,9 +171,9 @@ paths:
         'default':
           $ref: '#/components/responses/Errors'
 
-# -------------------------------------
-# UI: Imports
-# -------------------------------------
+  # -------------------------------------
+  # UI: Imports
+  # -------------------------------------
 
   '/_ui/imports/collections/':
     get:
@@ -193,9 +194,9 @@ paths:
         'default':
           $ref: '#/components/responses/Errors'
 
-# -------------------------------------
-# UI: Namespaces
-# -------------------------------------
+  # -------------------------------------
+  # UI: Namespaces
+  # -------------------------------------
 
   '/_ui/namespaces/':
     get:
@@ -244,9 +245,9 @@ paths:
         'default':
           $ref: '#/components/responses/Errors'
 
-# -------------------------------------
-# UI: Tags
-# -------------------------------------
+  # -------------------------------------
+  # UI: Tags
+  # -------------------------------------
 
   '/_ui/tags/':
     get:
@@ -260,9 +261,9 @@ paths:
         'default':
           $ref: '#/components/responses/Errors'
 
-# -------------------------------------
-# UI: Users
-# -------------------------------------
+  # -------------------------------------
+  # UI: Users
+  # -------------------------------------
 
   '/_ui/users/':
     get:
@@ -296,9 +297,9 @@ paths:
         'default':
           $ref: '#/components/responses/Errors'
 
-# -------------------------------------
-# UI: Profile
-# -------------------------------------
+  # -------------------------------------
+  # UI: Profile
+  # -------------------------------------
 
   '/_ui/profile/':
     get:
@@ -397,7 +398,7 @@ components:
           nullable: true
           type: string
       required:
-      - name
+        - name
 
     CollectionUiVersionSummary:
       type: object
@@ -600,9 +601,9 @@ components:
             - data
 
 
-# -------------------------------------
-# Schemas: Errors
-# -------------------------------------
+    # -------------------------------------
+    # Schemas: Errors
+    # -------------------------------------
 
     Errors:
       title: 'Errors'
@@ -664,9 +665,9 @@ components:
         - detail
         - status
 
-# -------------------------------------
-# Schemas: Namespaces
-# -------------------------------------
+    # -------------------------------------
+    # Schemas: Namespaces
+    # -------------------------------------
 
     Namespace:
       title: 'Namespace'
@@ -759,9 +760,9 @@ components:
           type: string
           format: uri
 
-# -------------------------------------
-# Schemas: Pagination
-# -------------------------------------
+    # -------------------------------------
+    # Schemas: Pagination
+    # -------------------------------------
 
     PageInfo:
       description: 'Pagination info'

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,13 @@ whitelist_externals =
     bash
     echo
 
-[testenv:flake8]
-deps = flake8
-commands = flake8 galaxy_api tests
+[testenv:linters]
+deps =
+    flake8
+    yamllint
+commands =
+    flake8 galaxy_api tests
+    yamllint -s .
 
 [flake8]
 max-line-length = 99


### PR DESCRIPTION
Make this repo passing the yamllint test and add/update the tox target
to harmonize with what other components within `ansible` namespace are
doing.

Namely:

  * `ansible/ansible-runner`
  * `ansible/awx`
  * `ansible-network/ansible_collections.vyos.vyos`
  * `ansible/workshops`

Signed-off-by: Yanis Guenane <yguenane@redhat.com>