### PR TITLE
Return 400 instead of 500 for galaxy_pulp client ValueErrors

### DIFF
--- a/galaxy_api/api/exceptions.py
+++ b/galaxy_api/api/exceptions.py
@@ -49,7 +49,7 @@ def _handle_api_client_exception(exc):
 def _handle_openapi_exception(exc, context=None):
     error = {'status': 400,
              'code': 'galaxy_pulp_api_error',
-             'detail': "{0}".format(exc)}
+             'detail': str(exc)}
 
     data = {'errors': [error]}
 

--- a/galaxy_api/api/exceptions.py
+++ b/galaxy_api/api/exceptions.py
@@ -46,10 +46,23 @@ def _handle_api_client_exception(exc):
     return HttpResponse(exc.body, status=exc.status, content_type=exc.headers['Content-Type'])
 
 
+def _handle_openapi_exception(exc, context=None):
+    error = {'status': 400,
+             'code': 'galaxy_pulp_api_error',
+             'detail': "{0}".format(exc)}
+
+    data = {'errors': [error]}
+
+    return Response(data, status=400)
+
+
 def exception_handler(exc, context):
     """Custom exception handler."""
     if isinstance(exc, galaxy_pulp.ApiException):
         return _handle_api_client_exception(exc)
+
+    if isinstance(exc, galaxy_pulp.OpenApiException):
+        return _handle_openapi_exception(exc, context)
 
     if isinstance(exc, Http404):
         exc = exceptions.NotFound()


### PR DESCRIPTION
For some endpoints, the query params received by galaxy-api
are passed to the pulp endpoints. But for some cases the
galaxy_pulp openapi generated bindings will raise a
galaxy_pulp.ApiTypeError (subclass of galaxy_pulp.OpenApiException).
This is raises before the request is made.

Previously, OpenApiException would result in exception_handler
returning None which causes DRF to return a 500 status code.

Fix by handling OpenApiException errors in the
drf exception_handle and returning a 400 status code instead.