### PR TITLE
Add specific info to col filename errors

### DIFF
--- a/galaxy_api/api/utils.py
+++ b/galaxy_api/api/utils.py
@@ -34,12 +34,14 @@ def parse_collection_filename(filename):
     match = FILENAME_REGEXP.match(filename)
 
     if not match:
-        raise ValueError("Invalid filename. Expected: {namespace}-{name}-{version}.tar.gz")
+        msg = "Invalid filename {0}. Expected format: {namespace}-{name}-{version}.tar.gz"
+        raise ValueError(msg.format(filename))
 
     namespace, name, version = match.groups()
 
     match = VERSION_REGEXP.match(version)
     if not match:
-        raise ValueError("Invalid version string. Expected semantic version format.")
+        msg = "Invalid version string {0} from filename {1}. Expected semantic version format."
+        raise ValueError(msg.format(version, filename))
 
     return CollectionFilename(namespace, name, version)

--- a/galaxy_api/api/utils.py
+++ b/galaxy_api/api/utils.py
@@ -34,14 +34,14 @@ def parse_collection_filename(filename):
     match = FILENAME_REGEXP.match(filename)
 
     if not match:
-        msg = "Invalid filename {0}. Expected format: {namespace}-{name}-{version}.tar.gz"
-        raise ValueError(msg.format(filename))
+        msg = "Invalid filename {filename}. Expected format: {namespace}-{name}-{version}.tar.gz"
+        raise ValueError(msg.format(filename=filename))
 
     namespace, name, version = match.groups()
 
     match = VERSION_REGEXP.match(version)
     if not match:
-        msg = "Invalid version string {0} from filename {1}. Expected semantic version format."
-        raise ValueError(msg.format(version, filename))
+        msg = "Invalid version string {version} from filename {filename}. Expected semantic version format." # noqa
+        raise ValueError(msg.format(version=version, filename=filename))
 
     return CollectionFilename(namespace, name, version)


### PR DESCRIPTION
Current error messages come out like:

`ValueError: Invalid version string. Expected semantic version format.`

When inspecting logs or error reports, this leaves out important info.