### PR TITLE
Fix 500 on filename value error

### DIFF
--- a/galaxy_api/api/utils.py
+++ b/galaxy_api/api/utils.py
@@ -34,12 +34,14 @@ def parse_collection_filename(filename):
     match = FILENAME_REGEXP.match(filename)
 
     if not match:
-        raise ValueError("Invalid filename. Expected: {namespace}-{name}-{version}.tar.gz")
+        msg = "Invalid filename {0}. Expected format: {namespace}-{name}-{version}.tar.gz"
+        raise ValueError(msg.format(filename))
 
     namespace, name, version = match.groups()
 
     match = VERSION_REGEXP.match(version)
     if not match:
-        raise ValueError("Invalid version string. Expected semantic version format.")
+        msg = "Invalid version string {0} from filename {1}. Expected semantic version format."
+        raise ValueError(msg.format(version, filename))
 
     return CollectionFilename(namespace, name, version)

--- a/galaxy_api/api/utils.py
+++ b/galaxy_api/api/utils.py
@@ -34,14 +34,14 @@ def parse_collection_filename(filename):
     match = FILENAME_REGEXP.match(filename)
 
     if not match:
-        msg = "Invalid filename {0}. Expected format: {namespace}-{name}-{version}.tar.gz"
-        raise ValueError(msg.format(filename))
+        msg = "Invalid filename {filename}. Expected format: {namespace}-{name}-{version}.tar.gz"
+        raise ValueError(msg.format(filename=filename))
 
     namespace, name, version = match.groups()
 
     match = VERSION_REGEXP.match(version)
     if not match:
-        msg = "Invalid version string {0} from filename {1}. Expected semantic version format."
-        raise ValueError(msg.format(version, filename))
+        msg = "Invalid version string {version} from filename {filename}. Expected semantic version format." # noqa
+        raise ValueError(msg.format(version=version, filename=filename))
 
     return CollectionFilename(namespace, name, version)


### PR DESCRIPTION
Fix 500's on imports with invalid filenames

Make CollectionUploadSerializer raise a drf
ValidationError if the filename isn't the right
format instead of a ValueError.

Raising a ValidationError causes django/drf to return
a 400 status code instead of the 500 returned for the
unhandled ValueError.

Also log the error message at error level, and add
specific info like the filename and version string to
the error message to make it easier to troubleshoot.

