### PR TITLE
log: Include request_id, add root logger

### DIFF
--- a/galaxy_api/settings.py
+++ b/galaxy_api/settings.py
@@ -144,12 +144,21 @@ PULP_CONTENT_PATH_PREFIX = '/api/automation-hub/v3/artifacts/collections/'
 # Application settings
 # ---------------------------------------------------------
 
+# Generate a request_id. Use for local dev. In prod/ci, the
+# the 3scale layer adds the X-request-id header
+REQUEST_ID_HEADER = None
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {
         'default': {
-            'format': '%(asctime)s %(levelname)s %(name)s: %(message)s',
+            'format': '%(asctime)s %(levelname)s %(name)s %(request_id)s: %(message)s',
+        },
+    },
+    "filters": {
+       "request_id": {
+            "()": "request_id.logging.RequestIdFilter"
         },
     },
     'handlers': {
@@ -157,11 +166,19 @@ LOGGING = {
             'level': 'INFO',
             'class': 'logging.StreamHandler',
             'formatter': 'default',
-        }
+            'filters': ["request_id"],
+        },
+    },
+    'root': {
+        'level': 'ERROR',
+        'handlers': ['console'],
     },
     'loggers': {
         'django': {
-            'handlers': ['console'],
+            'level': 'INFO',
+        },
+        'galaxy_api': {
+            'level': 'INFO',
         },
     }
 }


### PR DESCRIPTION
Generate a request_id for requests in local
dev config by setting REQUEST_ID_HEADER=None.
This generates a request_id for each request.

Prod/CI/QA env will need to set this back to:

REQUEST_ID_HEADER = 'HTTP_X_REQUEST_ID'

Attach a request_id filter to the 'console'
handler so console request include the request_id
log record field.

Add a root logger at ERROR level that logs to console.

Add a 'galaxy_api' logger at INFO level to catch app
logging.


**NOTE:** Since this turns on auto generation of request_id by default, the config settings.py used for CI/PROD will need to set it back. See https://github.com/RedHatInsights/e2e-deploy/pull/1022 for a pr to do that.
