### PR TITLE
test: Allow one to run tests locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,6 @@
 ---
 language: python
 python: '3.6'
-services:
-  - postgresql
-
-env:
-  - GALAXY_DB_USER=postgres
 
 cache:
   pip: true
@@ -24,4 +19,3 @@ jobs:
       script: tox -e py36
       services:
         - docker
-        - postgresql

--- a/bindings/build.sh
+++ b/bindings/build.sh
@@ -2,6 +2,13 @@
 
 bindings_dir=$(dirname $(readlink -f "$0"))
 
+docker run --rm \
+  --name postgres \
+  -e POSTGRES_PASSWORD='galaxy' \
+  -e POSTGRES_USER='galaxy' \
+  -p 5432:5432 \
+  -d postgres
+
 docker run --rm -u "$(id -u)" -v "${bindings_dir}:/local" \
   openapitools/openapi-generator-cli generate \
   -i /local/openapi.yaml \

--- a/galaxy_api/settings.py
+++ b/galaxy_api/settings.py
@@ -1,5 +1,6 @@
 """Project settings."""
 
+import os
 import sys
 
 from dynaconf import LazySettings
@@ -77,11 +78,11 @@ DATABASES = {
     'default': {
         # Gather metrics for 'django.db.backends.postgresql',
         'ENGINE': 'django_prometheus.db.backends.postgresql',
-        'NAME': settings.get('DB_NAME', 'galaxy'),
-        'USER': settings.get('DB_USER', 'galaxy'),
-        'PASSWORD': settings.get('DB_PASSWORD', ''),
-        'HOST': settings.get('DB_HOST', 'localhost'),
-        'PORT': settings.get('DB_PORT', ''),
+        'NAME': os.environ.get('GALAXY_DB_NAME', settings.get('DB_NAME', 'galaxy')),
+        'USER': os.environ.get('GALAXY_DB_USER', settings.get('DB_USER', 'galaxy')),
+        'PASSWORD': os.environ.get('GALAXY_DB_PASSWORD', settings.get('DB_PASSWORD', '')),
+        'HOST': os.environ.get('GALAXY_DB_HOST', settings.get('DB_HOST', 'localhost')),
+        'PORT': os.environ.get('GALAXY_DB_PORT', settings.get('DB_PORT', '')),
     }
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ passenv = GALAXY_*
 setenv =
     PIPENV_VERBOSITY=-1
     GALAXY_SECRET_KEY=secret
+    GALAXY_DB_PASSWORD=galaxy
 commands =
     bash ./bindings/build.sh
     pip install -e ./bindings/galaxy-pulp


### PR DESCRIPTION
This commit aims to allow one to run tests (unit-tests) on their local
machine on the same way it is run on the CI system simply via running
`tox -e py36`.